### PR TITLE
Fix state issues with Modifier.validationConfig

### DIFF
--- a/library/src/commonMain/kotlin/com/chrisjenx/yakcov/Modifiers.kt
+++ b/library/src/commonMain/kotlin/com/chrisjenx/yakcov/Modifiers.kt
@@ -1,6 +1,5 @@
 package com.chrisjenx.yakcov
 
-import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 
 /**
@@ -8,7 +7,6 @@ import androidx.compose.ui.Modifier
  *
  * @see ValueValidator.validationConfig
  */
-@Composable
 fun Modifier.validationConfig(
     validator: ValueValidator<*, *>,
     validateOnFocusLost: Boolean = false,


### PR DESCRIPTION
When testing, `validateOnFocusLost` randomly triggers maybe 1 out of 4 times focus is lost. I believe this is due to the combination of: 
- `hadFocus` being created on every composition without a `remember` block
- `hadFocus` being set using `focusState.hasFocus` while checking `focusState.isFocused`

In addition, state tracking with Modifiers is notoriously bad, which is what `Modifier.composed` is meant for; this also means you can call the modifier from a non-Composable context.