### PR TITLE
chore: target Compose Multiplatform 1.11.1 and refresh dependencies

### DIFF
--- a/RELEASE_SCRIPT.md
+++ b/RELEASE_SCRIPT.md
@@ -23,13 +23,16 @@ Defines the release channels at the project root:
 
 ```toml
 [stable]
-compose = "1.10.3"
-compose-material3 = "1.10.0-alpha05"
+compose = "1.11.1"
+compose-material3 = "1.11.0-alpha07"
+xcode = "26.3"  # Compose 1.11 iOS needs a newer Xcode than the runner default
 
-[next]
-compose = "1.11.0-beta02"
-compose-material3 = "1.11.0-alpha06"
-kotlin = "2.3.20"
+# The [next] beta channel is optional. Re-enable it to also build/publish against
+# the next development line (e.g. Compose 1.12):
+# [next]
+# compose = "1.12.0-alpha01"
+# compose-material3 = "1.12.0-alpha01"
+# kotlin = "2.4.0"
 ```
 
 | Key | Required | Description |
@@ -70,11 +73,8 @@ Remove a section to skip that channel. For example, removing `[next]` releases o
 ```
 [INFO] === Release Plan ===
 
-[stable] compose=1.10.3  material3=1.10.0-alpha05  kotlin=<inherited>
-[stable] tag=1.10.3
-
-[next] compose=1.11.0-beta02  material3=1.11.0-alpha06  kotlin=2.3.20
-[next] tag=1.11.0-beta02
+[stable] compose=1.11.1  material3=1.11.0-alpha07  kotlin=<inherited>
+[stable] tag=1.11.1
 
 Continue with release? (y/N):
 ```
@@ -83,8 +83,8 @@ Continue with release? (y/N):
 
 | Channel | First release | Subsequent releases |
 |---------|--------------|---------------------|
-| stable | `1.10.3` | `1.10.3-1`, `1.10.3-2` |
-| next | `1.11.0-beta02` | `1.11.0-beta02-1`, `1.11.0-beta02-2` |
+| stable | `1.11.1` | `1.11.1-1`, `1.11.1-2` |
+| next (when enabled) | `1.12.0-alpha01` | `1.12.0-alpha01-1`, `1.12.0-alpha01-2` |
 
 The script automatically detects existing tags and increments.
 
@@ -113,7 +113,7 @@ This validates: TOML parsing, tag computation, version patching, and restoration
 To publish manually without the script:
 
 ```bash
-./gradlew :library:publishAndReleaseToMavenCentral --no-configuration-cache -PpublishVersion=1.10.3
+./gradlew :library:publishAndReleaseToMavenCentral --no-configuration-cache -PpublishVersion=1.11.1
 ```
 
 ## CI Release (GitHub Actions)

--- a/compose-releases.toml
+++ b/compose-releases.toml
@@ -10,11 +10,19 @@
 #   xcode            - Xcode version for Apple CI builds (optional, uses runner default if omitted)
 
 [stable]
-compose = "1.10.3"
-compose-material3 = "1.10.0-alpha05"
-
-[next]
-compose = "1.11.0-beta02"
-compose-material3 = "1.11.0-alpha06"
-kotlin = "2.3.20"
+compose = "1.11.1"
+compose-material3 = "1.11.0-alpha07"
+# kotlin omitted -> inherits 2.3.21 from libs.versions.toml (>= 2.3.10, required by Compose 1.11 native/web)
+# Required: Compose 1.11's iOS skiko links against a newer SDK than the macos runner
+# default (Xcode 16.4 / iOS 18.5), which fails with "framework 'UIUtilities' not found".
+# Xcode 26.3 is installed on the macos-latest runner and links cleanly. Do not remove.
 xcode = "26.3"
+
+# The [next] (beta) channel is retired for now: Compose 1.11 has shipped (it is the
+# stable channel above) and there is no 1.11.x pre-release ahead of it to track.
+# Re-enable when you want to ride the next development line (e.g. Compose 1.12):
+# [next]
+# compose = "1.12.0-alpha01"
+# compose-material3 = "1.12.0-alpha01"
+# kotlin = "2.4.0"
+# xcode = "26.3"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,25 +1,28 @@
 [versions]
 agp = "8.12.3"
-androidx-activityCompose = "1.11.0"
-androidx-uiTest = "1.9.4"
+androidx-activityCompose = "1.13.0"
+androidx-uiTest = "1.11.2"
 # https://github.com/JetBrains/compose-multiplatform/releases
-compose = "1.10.0-beta01"
-compose-material3 = "1.10.0-alpha04"
+compose = "1.11.1"
+compose-material3 = "1.11.0-alpha07"
 # https://developer.android.com/develop/ui/compose/bom/bom-mapping
-composeBom = "2025.10.01"
+composeBom = "2026.05.01"
+# androidx.core 1.19.0 requires AGP 9.1+ / compileSdk 37; capped at 1.17.0 until the AGP 9 upgrade
 coreKtx = "1.17.0"
-kotlin = "2.2.21"
-kotlinx-datetime = "0.7.1"
-libphonenumber-kotlin = "0.1.8"
-lifecycleRuntimeKtx = "2.9.4"
+# Compose Multiplatform 1.11 requires Kotlin >= 2.3.10 for native/web targets
+kotlin = "2.3.21"
+kotlinx-datetime = "0.8.0"
+libphonenumber-kotlin = "0.1.9"
+lifecycleRuntimeKtx = "2.10.0"
 startupRuntime = "1.2.0"
 
 [libraries]
 androidx-activityCompose = { module = "androidx.activity:activity-compose", version.ref = "androidx-activityCompose" }
-androidx-compose-bom = { group = "androidx.compose", name = "compose-bom-beta", version.ref = "composeBom" }
+androidx-compose-bom = { group = "androidx.compose", name = "compose-bom", version.ref = "composeBom" }
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
 androidx-lifecycle-runtime-ktx = { group = "androidx.lifecycle", name = "lifecycle-runtime-ktx", version.ref = "lifecycleRuntimeKtx" }
 androidx-material3 = { group = "androidx.compose.material3", name = "material3" }
+androidx-material-icons-core = { group = "androidx.compose.material", name = "material-icons-core" }
 androidx-startup-runtime = { module = "androidx.startup:startup-runtime", version.ref = "startupRuntime" }
 androidx-testManifest = { module = "androidx.compose.ui:ui-test-manifest", version.ref = "androidx-uiTest" }
 androidx-ui = { group = "androidx.compose.ui", name = "ui" }

--- a/library/src/commonMain/kotlin/com/chrisjenx/yakcov/strings/StringValueValidatorRules.kt
+++ b/library/src/commonMain/kotlin/com/chrisjenx/yakcov/strings/StringValueValidatorRules.kt
@@ -203,7 +203,7 @@ data class DayValidation(val localDate: State<LocalDate>) : ValueValidatorRule<S
         val dayOfMonth = value.toIntOrNull()
             ?: return ResourceValidationResult.error(Res.string.ruleDay)
         runCatching {
-            LocalDate(current.year, current.monthNumber, dayOfMonth)
+            LocalDate(current.year, current.month, dayOfMonth)
         }.onFailure {
             return ResourceValidationResult.error(Res.string.ruleInvalidDate, it.message ?: "")
         }
@@ -220,7 +220,7 @@ data class MonthValidation(val localDate: State<LocalDate>) : ValueValidatorRule
         val monthOfYear = value.toIntOrNull()
             ?: return ResourceValidationResult.error(Res.string.ruleMonth)
         runCatching {
-            LocalDate(current.year, monthOfYear, current.dayOfMonth)
+            LocalDate(current.year, monthOfYear, current.day)
         }.onFailure {
             return ResourceValidationResult.error(Res.string.ruleInvalidDate, it.message ?: "")
         }
@@ -236,7 +236,7 @@ data class YearValidation(val localDate: State<LocalDate>) : ValueValidatorRule<
         val current = localDate.value
         val year = value.toIntOrNull() ?: return ResourceValidationResult.error(Res.string.ruleYear)
         runCatching {
-            LocalDate(year, current.monthNumber, current.dayOfMonth)
+            LocalDate(year, current.month, current.day)
         }.onFailure {
             return ResourceValidationResult.error(Res.string.ruleInvalidDate, it.message ?: "")
         }

--- a/library/src/commonTest/kotlin/com/chrisjenx/yakcov/strings/DateRuleTest.kt
+++ b/library/src/commonTest/kotlin/com/chrisjenx/yakcov/strings/DateRuleTest.kt
@@ -1,0 +1,75 @@
+package com.chrisjenx.yakcov.strings
+
+import com.chrisjenx.yakcov.ValidationResult.Outcome
+import kotlinx.datetime.LocalDate
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * Regression coverage for [DayValidation], [MonthValidation] and [YearValidation].
+ *
+ * Each rule rebuilds a [LocalDate] from the reference date plus the field under
+ * validation. These tests were added when migrating off the deprecated
+ * kotlinx-datetime `LocalDate.monthNumber`/`dayOfMonth` accessors (now `month`/`day`)
+ * to confirm the date-construction behaviour is unchanged, including leap-year and
+ * day-overflow edge cases that exercise the `month`/`day` accessors directly.
+ */
+class DateRuleTest {
+
+    // DayValidation: validates day-of-month against the reference's year + month.
+
+    @Test
+    fun day_valid_in_leap_february_success() {
+        // Feb 2024 is a leap month, so day 29 is valid.
+        assertEquals(Outcome.SUCCESS, DayValidation(LocalDate(2024, 2, 1)).validate("29").outcome())
+    }
+
+    @Test
+    fun day_overflow_for_month_error() {
+        // February never has a 30th.
+        assertEquals(Outcome.ERROR, DayValidation(LocalDate(2024, 2, 1)).validate("30").outcome())
+    }
+
+    @Test
+    fun day_non_numeric_error() {
+        assertEquals(Outcome.ERROR, DayValidation(LocalDate(2024, 2, 1)).validate("abc").outcome())
+    }
+
+    // MonthValidation: validates month against the reference's year + day.
+
+    @Test
+    fun month_valid_for_reference_day_success() {
+        // Reference day 31; March has 31 days.
+        assertEquals(Outcome.SUCCESS, MonthValidation(LocalDate(2024, 1, 31)).validate("3").outcome())
+    }
+
+    @Test
+    fun month_with_invalid_day_for_month_error() {
+        // Reference day 31; February has no 31st.
+        assertEquals(Outcome.ERROR, MonthValidation(LocalDate(2024, 1, 31)).validate("2").outcome())
+    }
+
+    @Test
+    fun month_out_of_range_error() {
+        assertEquals(Outcome.ERROR, MonthValidation(LocalDate(2024, 1, 15)).validate("13").outcome())
+    }
+
+    // YearValidation: validates year against the reference's month + day.
+
+    @Test
+    fun year_leap_keeps_feb29_success() {
+        // 2024 is a leap year, so Feb 29 2024 is valid.
+        assertEquals(Outcome.SUCCESS, YearValidation(LocalDate(2024, 2, 29)).validate("2024").outcome())
+    }
+
+    @Test
+    fun year_non_leap_rejects_feb29_error() {
+        // 2023 is not a leap year, so Feb 29 2023 is invalid.
+        assertEquals(Outcome.ERROR, YearValidation(LocalDate(2024, 2, 29)).validate("2023").outcome())
+    }
+
+    @Test
+    fun year_non_numeric_error() {
+        assertEquals(Outcome.ERROR, YearValidation(LocalDate(2024, 2, 29)).validate("abc").outcome())
+    }
+}

--- a/sample/build.gradle.kts
+++ b/sample/build.gradle.kts
@@ -68,6 +68,8 @@ dependencies {
     implementation(libs.androidx.ui.graphics)
     implementation(libs.androidx.ui.tooling.preview)
     implementation(libs.androidx.material3)
+    // material-icons-core is no longer pulled transitively by material3 in recent Compose BOMs
+    implementation(libs.androidx.material.icons.core)
     debugImplementation(libs.androidx.ui.tooling)
     debugImplementation(libs.androidx.testManifest)
 }


### PR DESCRIPTION
## Summary

Promotes the library's primary target to **Compose Multiplatform 1.11.1** and refreshes dependencies that are compatible with the current **AGP 8 / Gradle 8** toolchain. The AGP 9 / Gradle 9 jump is intentionally **deferred** (kept this focused on Compose 1.11.x).

## Working defaults — `gradle/libs.versions.toml`

| Dependency | Before | After |
|---|---|---|
| compose | 1.10.0-beta01 | **1.11.1** |
| compose-material3 | 1.10.0-alpha04 | **1.11.0-alpha07** |
| kotlin | 2.2.21 | **2.3.21** (≥2.3.10 required by Compose 1.11 native/web; compose-compiler tracks it) |
| compose BOM | 2025.10.01 `compose-bom-beta` | **2026.05.01 `compose-bom`** (stable artifact, now at parity) |
| activity-compose | 1.11.0 | **1.13.0** |
| ui-test (compose) | 1.9.4 | **1.11.2** |
| lifecycle-runtime-ktx | 2.9.4 | **2.10.0** |
| kotlinx-datetime | 0.7.1 | **0.8.0** |
| libphonenumber-kotlin | 0.1.8 | **0.1.9** |
| core-ktx | 1.17.0 | **held** (1.19.0 needs AGP 9.1 / compileSdk 37) |

## Release channels — `compose-releases.toml`
- **stable** → Compose 1.11.1 / material3 1.11.0-alpha07
- **next** channel **retired for now** — 1.11 has shipped and there's no 1.11.x pre-release ahead of stable to track. Left as a commented template for a future 1.12 line.

## Code changes
- Migrated off the deprecated kotlinx-datetime `LocalDate.monthNumber`/`dayOfMonth` → `month`/`day` in the Day/Month/Year validation rules.
- Added `material-icons-core` to the **sample** (no longer pulled transitively by material3 in recent Compose BOMs).
- Added `DateRuleTest` covering the previously-untested date validation rules (9 cases incl. leap-year/day-overflow edges).

## Verification
- ✅ Clean `:library:allTests` — **28 tests/platform, 0 failures** across JVM, Android (debug+release), JS, WasmJS, iOS-sim.
- ✅ `:sample:assembleRelease` (R8/proguard).
- ✅ `:library:build` (release dry-run path).
- ✅ **Old-vs-new baseline**: original committed versions produce byte-identical test outcomes (same counts, skips, 0 failures) → no behavioral regression; the date migration is provably behavior-preserving.

## Follow-ups (not in this PR)
- Compose 1.11 test API: `runComposeUiTest` → `androidx.compose.ui.test.v2.runComposeUiTest` (28 test-only deprecation warnings; v2 changes dispatcher semantics).
- The deferred toolchain jump: AGP 9.2.1 + Gradle 9.4.1 + vanniktech-publish 0.36 (Dokka v2) + core-ktx 1.19 + compileSdk 37.

🤖 Generated with [Claude Code](https://claude.com/claude-code)