### PR TITLE
docs: GitHub Pages docs site with compiled pattern examples

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -97,7 +97,7 @@ jobs:
       - name: Patch Compose versions
         run: ./scripts/lib-release.sh --patch "${{ matrix.channel }}"
       - name: Run Android and JVM tests
-        run: ./gradlew :library:testDebugUnitTest :library:jvmTest --warn --continue
+        run: ./gradlew :library:testDebugUnitTest :library:jvmTest :docs-examples:compileDebugKotlinAndroid :docs-examples:compileKotlinJvm --warn --continue
       - name: Publish Test Report
         uses: mikepenz/action-junit-report@v4
         if: success() || failure()

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -8,13 +8,22 @@ on:
       - 'docs-examples/**'
       - 'mkdocs.yml'
       - '.github/workflows/docs.yml'
+  # Validate (strict build) on PRs too — snippet markers are comments, so a renamed
+  # marker or moved file compiles green; only `mkdocs build --strict` catches the
+  # broken include. Without this the drift only surfaces post-merge on the deploy run.
+  pull_request:
+    paths:
+      - 'docs/**'
+      - 'docs-examples/**'
+      - 'mkdocs.yml'
+      - '.github/workflows/docs.yml'
   workflow_dispatch:
 
 permissions:
   contents: write  # mkdocs gh-deploy pushes the gh-pages branch
 
 jobs:
-  deploy:
+  docs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -25,11 +34,16 @@ jobs:
           python-version: '3.12'
       - name: Install MkDocs Material
         run: pip install mkdocs-material
-      - name: Build (strict — fails on broken snippet includes)
+      # PRs validate only; push to main builds-and-deploys in one step (gh-deploy
+      # builds internally, so a separate `mkdocs build` would build the site twice).
+      - name: Validate (strict — fails on broken snippet includes)
+        if: github.event_name != 'push'
         run: mkdocs build --strict
       - name: Configure git for gh-pages push
+        if: github.event_name == 'push'
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
       - name: Deploy to GitHub Pages
-        run: mkdocs gh-deploy --force
+        if: github.event_name == 'push'
+        run: mkdocs gh-deploy --strict --force

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,35 @@
+name: Docs
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'docs/**'
+      - 'docs-examples/**'
+      - 'mkdocs.yml'
+      - '.github/workflows/docs.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: write  # mkdocs gh-deploy pushes the gh-pages branch
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Install MkDocs Material
+        run: pip install mkdocs-material
+      - name: Build (strict — fails on broken snippet includes)
+        run: mkdocs build --strict
+      - name: Configure git for gh-pages push
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+      - name: Deploy to GitHub Pages
+        run: mkdocs gh-deploy --force

--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,6 @@ docs/superpowers/
 # superpowers git worktree dirs (.worktrees preferred, worktrees is the fallback)
 .worktrees/
 worktrees/
+
+# MkDocs build output
+site/

--- a/README.MD
+++ b/README.MD
@@ -4,215 +4,69 @@
 
 `TextField` validation is a pain, hopefully this is a bit easier
 
+**[Full documentation & pattern guides →](https://chrisjenx.github.io/yakcov/)**
+— basic screens, [ViewModel](https://chrisjenx.github.io/yakcov/patterns/viewmodel/),
+[MVI/UDF](https://chrisjenx.github.io/yakcov/patterns/mvi/), and
+[Circuit](https://chrisjenx.github.io/yakcov/patterns/circuit/) wiring, with every
+example compiled in CI against the current API.
+
 ![](sample/assets/YakcovDemo.gif)
 
+<!-- keep in sync with docs-examples/src/commonMain/kotlin/com/chrisjenx/yakcov/docs/basic/BasicScreen.kt -->
 ```kotlin
-val emailValidator = rememberTextFieldValueValidator(
-    rules = listOf(Required, Email)
-)
-with(emailValidator) {
-    OutlinedTextField(
-        value = value,
-        onValueChange = ::onValueChange,
-        modifier = Modifier
-            .validationConfig(
-                // will start validation on loss of focus
-                validateOnFocusLost = true,
-                // will shake the field when invalid and validate() is called
-                shakeOnInvalid = true,
-                // when false will delay [isError] until validate() is called
-                showErrorOnInteraction = false,
-            )
-            .fillMaxWidth(),
-        label = { Text("Email*") },
-        placeholder = { Text("Email") },
-        leadingIcon = { Icon(Icons.Default.Email, contentDescription = "Email") },
-        isError = isError(), // will mark the field error when validation has started and is invalid
-        supportingText = supportingText(), // will show the validation message, or error message
-    )
-}
-```
-
-### Presenter-driven validation (headless)
-
-Yakcov also works when a **presenter owns the form state** — useful for snapshot-presenter
-(Molecule) and reducer-MVI screens. The field draft and validity become unit-testable without
-entering composition; only the message render (`text()` / `supportingText()`) stays in Compose.
-
-**(a) Snapshot / Molecule presenter** — the presenter owns a mutable `FieldValidator`:
-
-```kotlin
-// presenter — owns the FieldValidator as a field; draft + validity testable without composition
-class CheckoutPresenter {
-    val email = FieldValidator("", listOf(Required, Email))
-    // CurrencyAmount here is your own ValueValidatorRule — compose built-ins with your domain rules
-    val amount = FieldValidator("", listOf(Required, CurrencyAmount))
-
-    fun submit(): Boolean = listOf(email, amount).validate() // shows errors, then checks
-}
-
-// reusable binder, written once in app code (one line per field at the call site)
 @Composable
-fun ValidatedTextField(field: FieldValidator<String>, label: String, modifier: Modifier = Modifier) {
-    OutlinedTextField(
-        value = field.value,
-        onValueChange = field::onValueChange,
-        label = { Text(label) },
-        isError = field.state.isError,
-        supportingText = field.state.supportingText(),
-        modifier = modifier.onFocusLost { field.onFocusLost() },
-    )
-}
+fun BasicSignUpScreen(onSubmit: (email: String, password: String) -> Unit) {
+    // No state holder: the validators live in the composable, remembered across
+    // recompositions. Each one owns its TextFieldValue draft + validation state.
+    val email = rememberTextFieldValueValidator(rules = listOf(Required, Email))
+    val password = rememberTextFieldValueValidator(rules = listOf(Required, MinLength(8)))
 
-ValidatedTextField(presenter.email, label = "Email")
-```
-
-> Construct a `FieldValidator` **once** and hold it (a presenter class / DI / `remember`). Don't
-> construct it inside a recomposing presenter body, and don't copy it — both reset its state.
-
-**Observability:** `FieldValidator` takes an optional `observer` — a `FieldValidatorObserver`
-fired after every mutation commits (`ValueChanged` / `Validated` / `Reset`) with the post-mutation
-value + state. Handy for analytics, logging, or driving UI like the sample's live state-flow
-visualizer ([StateFlowSample](sample/src/main/java/com/chrisjenx/yakcov/sample/StateFlowSample.kt)).
-No event fires at construction; observers must not throw.
-
-The binder above uses the `String` overload of `OutlinedTextField` for brevity. For reformatting
-fields (currency, phone) bind a local `TextFieldValue` and push only `.text` to `onValueChange` so the
-cursor/selection survives — see `ValidatedTextField` in the [sample](sample/src/main/java/com/chrisjenx/yakcov/sample/PresenterSample.kt).
-
-**(b) Reducer-MVI** — keep your `Model` immutable; store each field's draft + its serializable
-`FieldValidationState` and recompute with the pure `toFieldState` fold in `reduce()` (no
-`FieldValidator`, no Compose, no IO — so `reduce` is unit-testable without composition). `severity`
-is recomputed on every keystroke and answers *"is it valid?"* (drives `canSubmit`); `showError` only
-flips true on focus-loss/submit and answers *"show the error yet?"* (drives the red text). That split is
-yakcov's whole value. Cross-field rules go the pure way — an inline `ValueValidatorRule` closing over
-the other draft; the built-in `PasswordMatches` couples to a *mutable* validator and does **not** fit
-a reducer.
-
-```kotlin
-private val emailRules = listOf(Required, Email)
-private val passwordRules = listOf(Required, MinLength(8))
-// PURE cross-field rule: a SAM closing over the current password draft (rebuilt in reduce).
-private fun confirmRules(password: String) = listOf<ValueValidatorRule<String>>(
-    Required,
-    ValueValidatorRule { if (it == password) RegularValidationResult.success()
-                         else RegularValidationResult.error("Passwords do not match") },
-)
-
-enum class Field { Email, Password, Confirm }
-
-data class Model(
-    val emailDraft: String = "",    val emailState: FieldValidationState = FieldValidationState.Pristine,
-    val passwordDraft: String = "", val passwordState: FieldValidationState = FieldValidationState.Pristine,
-    val confirmDraft: String = "",  val confirmState: FieldValidationState = FieldValidationState.Pristine,
-    val submitted: Boolean? = null, // null = not attempted, true = accepted, false = blocked
-) {
-    // SEVERITY-only validity (ignores showError) — live from the first frame (drive a label or disable Submit).
-    val canSubmit get() = listOf(emailState, passwordState, confirmState).hasNoErrors()
-}
-
-sealed interface Event {
-    data class Changed(val field: Field, val text: String) : Event
-    data class FocusLost(val field: Field) : Event // show errors on one field
-    data object Submit : Event                     // show errors on all
-}
-
-// PURE: (Model, Event) -> Model. Copy this into a unit test as-is.
-fun reduce(model: Model, event: Event): Model = when (event) {
-    is Event.Changed -> when (event.field) {
-        // typing: recompute severity live, but PRESERVE showError (no error pops mid-keystroke)
-        Field.Email    -> model.copy(emailDraft = event.text,
-            emailState = emailRules.toFieldState(event.text, model.emailState.showError), submitted = null)
-        Field.Password -> model.copy(passwordDraft = event.text,
-            passwordState = passwordRules.toFieldState(event.text, model.passwordState.showError),
-            // password drives the cross-field rule — re-fold confirm against the new password
-            confirmState = confirmRules(event.text).toFieldState(model.confirmDraft, model.confirmState.showError),
-            submitted = null)
-        Field.Confirm  -> model.copy(confirmDraft = event.text,
-            confirmState = confirmRules(model.passwordDraft).toFieldState(event.text, model.confirmState.showError),
-            submitted = null)
+    Column {
+        with(email) {
+            OutlinedTextField(
+                value = value,
+                onValueChange = ::onValueChange,
+                label = { Text("Email") },
+                isError = isError(),
+                supportingText = supportingText(),
+                singleLine = true,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    // Show errors when focus leaves the field; shake on invalid submit.
+                    .validationConfig(validateOnFocusLost = true, shakeOnInvalid = true),
+            )
+        }
+        with(password) {
+            OutlinedTextField(
+                value = value,
+                onValueChange = ::onValueChange,
+                label = { Text("Password") },
+                isError = isError(),
+                supportingText = supportingText(),
+                singleLine = true,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .validationConfig(validateOnFocusLost = true, shakeOnInvalid = true),
+            )
+        }
+        Button(
+            onClick = {
+                // Form-level validate(): surfaces errors on every field, true when all pass.
+                if (listOf(email, password).validate()) {
+                    onSubmit(email.value.text, password.value.text)
+                }
+            },
+            modifier = Modifier.fillMaxWidth(),
+        ) { Text("Create account") }
     }
-    is Event.FocusLost -> when (event.field) {  // show errors on just that one field (showError = true)
-        Field.Email    -> model.copy(emailState = emailRules.toFieldState(model.emailDraft, showError = true))
-        Field.Password -> model.copy(passwordState = passwordRules.toFieldState(model.passwordDraft, showError = true))
-        Field.Confirm  -> model.copy(confirmState = confirmRules(model.passwordDraft).toFieldState(model.confirmDraft, showError = true))
-    }
-    Event.Submit -> model.copy(  // show errors on ALL, then record acceptance off severity
-        emailState    = emailRules.toFieldState(model.emailDraft, showError = true),
-        passwordState = passwordRules.toFieldState(model.passwordDraft, showError = true),
-        confirmState  = confirmRules(model.passwordDraft).toFieldState(model.confirmDraft, showError = true),
-    ).let { it.copy(submitted = it.canSubmit) }
 }
-
-// Seed by running the rules with showError = false (NOT Pristine) so canSubmit is honest at load —
-// hasNoErrors() treats a never-validated Pristine field as valid even if it's required + empty.
-fun initialModel() = Model(
-    emailState = emailRules.toFieldState("", showError = false),
-    passwordState = passwordRules.toFieldState("", showError = false),
-    confirmState = confirmRules("").toFieldState("", showError = false),
-)
 ```
 
-A minimal store needs no ViewModel — `mutableStateOf` is already observable. Keep it `@Stable` (it
-owns a `mutableStateOf`); do NOT mark it `@Immutable`:
-
-```kotlin
-@Stable
-class Store(initial: Model) {
-    var model by mutableStateOf(initial); private set
-    fun dispatch(e: Event) { model = reduce(model, e) }
-}
-// UI = f(state). For process-death survival hold the store via rememberSaveable with a Saver that
-// persists the drafts + each field's showError and re-runs the rules on restore (see MviSample.kt
-// for the full storeSaver/modelSaver wiring):
-// val store = rememberSaveable(saver = storeSaver) { Store(initialModel()) }
-// OutlinedTextField(value = store.model.emailDraft,
-//     onValueChange = { store.dispatch(Event.Changed(Field.Email, it)) },
-//     isError = store.model.emailState.isError,                 // gated on showError
-//     supportingText = store.model.emailState.supportingText(), // null until shown
-//     modifier = Modifier.onFocusLost { store.dispatch(Event.FocusLost(Field.Email)) })
-// Button(onClick = { store.dispatch(Event.Submit) }) {         // enabled; Submit shows errors on untouched fields
-//     Text(if (store.model.canSubmit) "Create account" else "Fix errors") // label is severity-driven
-// }
-```
-
-**Shake** stays UI-owned: keep a `rememberShakingState()` in the screen and call `shakingState.shake()`
-when an invalid submit reduces `submitted` to `false`.
-
-**Persistence (no new dep):** `FieldValidationState` is `@Immutable @Serializable` — only `severity`
-+ `showError` persist; the message (`result`) is `@Transient` and recomputes. Persist the whole model
-with `rememberSaveable` and a `Saver` that stores the drafts + each field's `showError`, then
-**rehydrate on restore by re-running the rules through `toFieldState`** so the transient message
-reappears with `showError` preserved (`runtime-saveable` comes transitively with material3). For
-cross-process JSON instead, add a kotlinx-serialization runtime and encode `FieldValidationState`
-directly (it persists `Outcome` by constant *name*). On the Molecule/`FieldValidator` path (a) the
-same idea applies: persist the draft + `showError` yourself, reconstruct
-`FieldValidator(initial = restoredDraft, rules)` and call `validate()`/`onFocusLost()` when `showError`
-was true (or construct with `initialValidate = true`) before first composition, so the rules re-run and
-a previously-shown message reappears. If you attach an `observer`, prefer the
-`initialValidate = true` form on restore — it fires no event, whereas `validate()`/`onFocusLost()` emit
-a `Validated` event that an analytics tap would over-count as a real focus-loss/submit.
-
-See the runnable, process-death-surviving multi-field version in the
-[sample](sample/src/main/java/com/chrisjenx/yakcov/sample/MviSample.kt).
-
-> Yakcov declares `kotlinx-serialization-core`, `compose-runtime`, and `compose-runtime-saveable` as
-> `compileOnly`. If you serialize `FieldValidationState`, add a serialization runtime (e.g.
-> `kotlinx-serialization-json`). If you use `FieldValidationState.Saver` / `rememberSaveable`, make
-> sure `org.jetbrains.compose.runtime:runtime-saveable` is on the classpath (it comes transitively
-> with `compose-foundation`/`material3`, so any Compose-UI module already has it). If your presenter
-> **unit tests** construct `FieldValidator` or read `.value`/`.state`, add `org.jetbrains.compose:runtime`
-> to your test source set (it is not pulled transitively).
-
-### Other Features
-
-- Multiplatform support! Android, JVM, JS, Wasm, iOS!
-- `TextFieldValueValidator` - a validator for `TextFieldValue` that can be used with `TextField` and `OutlinedTextField`
-- `GenericValueValidator` - a generic validator that can be used to validate any type
-  - Can use with any Composable, not just `TextField`s!
-- Build in `ValueValidatorRule`s to make putting forms together easier
-- `Outcome` - Supports different levels of severity for validation messages, `Error`, `Warning`, `Info`, `Success`
-- `ValidationConfig` - Allows you to configure how the validation should behave to user interaction
+Prefer the state holder to own the form? Yakcov also works headlessly — a
+ViewModel/presenter owns a `FieldValidator`, or a pure MVI reducer folds rules with
+`toFieldState`. See the
+[ViewModel](https://chrisjenx.github.io/yakcov/patterns/viewmodel/) and
+[MVI/UDF](https://chrisjenx.github.io/yakcov/patterns/mvi/) guides.
 
 ## Dependencies
 
@@ -238,19 +92,8 @@ dependencies {
 }
 ```
 
-### Phone number validation (libphonenumber)
-
-Yakcov's phone-number validation rules uses [luca992](https://github.com/luca992/libphonenumber-kotlin) port of libphonenumber. The Yakcov library declares this as `compileOnly`, so if you plan to use any phone-number validation rules you must add the dependency yourself in your app or shared module.
-
-Kotlin Multiplatform (recommended):
-
-```kotlin
-commonMain {
-    dependencies {
-        implementation("io.github.luca992.libphonenumber-kotlin:libphonenumber:0.1.8")
-    }
-}
-```
+Phone-number rules need the (compileOnly) libphonenumber dependency added to your app —
+see [phone validation](https://chrisjenx.github.io/yakcov/recipes/phone/).
 
 ## Build locally
 

--- a/docs-examples/build.gradle.kts
+++ b/docs-examples/build.gradle.kts
@@ -1,0 +1,64 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+
+/*
+ * Compiled documentation examples — NOT published.
+ *
+ * Every code block on the docs site is pulled from this module via pymdownx.snippets
+ * named markers (`// --8<-- [start:name]`), so examples can never silently drift from
+ * the library API: if the API changes, this module stops compiling and CI fails
+ * (see .github/workflows/checks.yml).
+ *
+ * JVM + Android targets only — enough to prove the wiring compiles without stressing
+ * the build (full multiplatform builds OOM locally at -Xmx4G).
+ */
+plugins {
+    alias(libs.plugins.multiplatform)
+    alias(libs.plugins.android.library)
+    alias(libs.plugins.compose.compiler)
+    alias(libs.plugins.compose)
+}
+
+kotlin {
+    androidTarget {
+        compilations.all {
+            compileTaskProvider {
+                compilerOptions {
+                    jvmTarget.set(JvmTarget.JVM_1_8)
+                }
+            }
+        }
+    }
+
+    jvm()
+
+    sourceSets {
+        commonMain.dependencies {
+            implementation(project(":library"))
+            // :library declares Compose as compileOnly — consumers (and these examples)
+            // supply the Compose runtime themselves, like the library's own tests do.
+            implementation(libs.jetbrains.compose.runtime)
+            implementation(libs.jetbrains.compose.foundation)
+            implementation(libs.jetbrains.compose.material3)
+            implementation(libs.jetbrains.compose.components.resources)
+            // Phone() recipe — the library declares libphonenumber compileOnly,
+            // so apps using the Phone rule must add it (see docs/recipes/phone.md).
+            implementation(libs.libphonenumber.kotlin)
+            // ViewModel pattern (KMP artifact: desktop + android)
+            implementation(libs.jetbrains.lifecycle.viewmodel.compose)
+            // Circuit pattern
+            implementation(libs.circuit.foundation)
+        }
+    }
+}
+
+android {
+    namespace = "com.chrisjenx.yakcov.docs"
+    compileSdk = 36
+    defaultConfig {
+        minSdk = 23
+    }
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_1_8
+        targetCompatibility = JavaVersion.VERSION_1_8
+    }
+}

--- a/docs-examples/src/commonMain/kotlin/com/chrisjenx/yakcov/docs/basic/BasicScreen.kt
+++ b/docs-examples/src/commonMain/kotlin/com/chrisjenx/yakcov/docs/basic/BasicScreen.kt
@@ -1,0 +1,63 @@
+package com.chrisjenx.yakcov.docs.basic
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material3.Button
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import com.chrisjenx.yakcov.strings.Email
+import com.chrisjenx.yakcov.strings.MinLength
+import com.chrisjenx.yakcov.strings.Required
+import com.chrisjenx.yakcov.strings.rememberTextFieldValueValidator
+import com.chrisjenx.yakcov.validate
+
+// --8<-- [start:basic]
+@Composable
+fun BasicSignUpScreen(onSubmit: (email: String, password: String) -> Unit) {
+    // No state holder: the validators live in the composable, remembered across
+    // recompositions. Each one owns its TextFieldValue draft + validation state.
+    val email = rememberTextFieldValueValidator(rules = listOf(Required, Email))
+    val password = rememberTextFieldValueValidator(rules = listOf(Required, MinLength(8)))
+
+    Column {
+        with(email) {
+            OutlinedTextField(
+                value = value,
+                onValueChange = ::onValueChange,
+                label = { Text("Email") },
+                isError = isError(),
+                supportingText = supportingText(),
+                singleLine = true,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    // Show errors when focus leaves the field; shake on invalid submit.
+                    .validationConfig(validateOnFocusLost = true, shakeOnInvalid = true),
+            )
+        }
+        with(password) {
+            OutlinedTextField(
+                value = value,
+                onValueChange = ::onValueChange,
+                label = { Text("Password") },
+                isError = isError(),
+                supportingText = supportingText(),
+                singleLine = true,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .validationConfig(validateOnFocusLost = true, shakeOnInvalid = true),
+            )
+        }
+        Button(
+            onClick = {
+                // Form-level validate(): surfaces errors on every field, true when all pass.
+                if (listOf(email, password).validate()) {
+                    onSubmit(email.value.text, password.value.text)
+                }
+            },
+            modifier = Modifier.fillMaxWidth(),
+        ) { Text("Create account") }
+    }
+}
+// --8<-- [end:basic]

--- a/docs-examples/src/commonMain/kotlin/com/chrisjenx/yakcov/docs/circuit/CircuitExample.kt
+++ b/docs-examples/src/commonMain/kotlin/com/chrisjenx/yakcov/docs/circuit/CircuitExample.kt
@@ -1,0 +1,100 @@
+package com.chrisjenx.yakcov.docs.circuit
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material3.Button
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import com.chrisjenx.yakcov.FieldValidator
+import com.chrisjenx.yakcov.onFocusLost
+import com.chrisjenx.yakcov.strings.Email
+import com.chrisjenx.yakcov.strings.MinLength
+import com.chrisjenx.yakcov.strings.Required
+import com.chrisjenx.yakcov.supportingText
+import com.chrisjenx.yakcov.validate
+import com.slack.circuit.runtime.CircuitUiEvent
+import com.slack.circuit.runtime.CircuitUiState
+import com.slack.circuit.runtime.presenter.Presenter
+
+// --8<-- [start:circuit-state]
+/** Circuit state: validators ride along as @Stable references; events flow back via the sink. */
+data class SignUpState(
+    val email: FieldValidator<String>,
+    val password: FieldValidator<String>,
+    val submitted: Boolean?,
+    val eventSink: (SignUpEvent) -> Unit,
+) : CircuitUiState
+
+sealed interface SignUpEvent : CircuitUiEvent {
+    data object Submit : SignUpEvent
+}
+// --8<-- [end:circuit-state]
+
+// --8<-- [start:circuit-presenter]
+class SignUpPresenter : Presenter<SignUpState> {
+    @Composable
+    override fun present(): SignUpState {
+        // Circuit presenters are composable functions, so `remember` keeps the
+        // validators (and the in-flight draft) across recompositions.
+        val email = remember { FieldValidator("", rules = listOf(Required, Email)) }
+        val password = remember { FieldValidator("", rules = listOf(Required, MinLength(8))) }
+        var submitted by remember { mutableStateOf<Boolean?>(null) }
+        return SignUpState(email, password, submitted) { event ->
+            when (event) {
+                // Form-level validate(): shows errors on every field, true when all pass.
+                SignUpEvent.Submit -> submitted = listOf(email, password).validate()
+            }
+        }
+    }
+}
+// --8<-- [end:circuit-presenter]
+
+// --8<-- [start:circuit-ui]
+@Composable
+fun SignUpUi(state: SignUpState, modifier: Modifier = Modifier) {
+    Column(modifier) {
+        ValidatedField(state.email, label = "Email")
+        ValidatedField(state.password, label = "Password")
+        Button(
+            onClick = { state.eventSink(SignUpEvent.Submit) },
+            modifier = Modifier.fillMaxWidth(),
+        ) { Text("Create account") }
+        state.submitted?.let { Text(if (it) "Valid — proceeding" else "Fix the errors above") }
+    }
+}
+
+@Composable
+private fun ValidatedField(field: FieldValidator<String>, label: String) {
+    OutlinedTextField(
+        value = field.value,
+        onValueChange = field::onValueChange,
+        label = { Text(label) },
+        isError = field.state.isError,
+        supportingText = field.state.supportingText(),
+        singleLine = true,
+        modifier = Modifier
+            .fillMaxWidth()
+            .onFocusLost { field.onFocusLost() },
+    )
+}
+// --8<-- [end:circuit-ui]
+
+// --8<-- [start:circuit-host]
+/**
+ * Minimal host. In a real app you register SignUpPresenter/SignUpUi in a Circuit via
+ * Presenter.Factory + Ui.Factory and render through CircuitContent(screen); a routed
+ * Screen needs @Parcelize on Android, which is app-level wiring beyond validation —
+ * so we keep it out of this example.
+ */
+@Composable
+fun SignUpCircuitHost() {
+    val presenter = remember { SignUpPresenter() }
+    SignUpUi(presenter.present())
+}
+// --8<-- [end:circuit-host]

--- a/docs-examples/src/commonMain/kotlin/com/chrisjenx/yakcov/docs/mvi/MviExample.kt
+++ b/docs-examples/src/commonMain/kotlin/com/chrisjenx/yakcov/docs/mvi/MviExample.kt
@@ -1,0 +1,137 @@
+package com.chrisjenx.yakcov.docs.mvi
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material3.Button
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Stable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import com.chrisjenx.yakcov.FieldValidationState
+import com.chrisjenx.yakcov.ValueValidatorRule
+import com.chrisjenx.yakcov.hasNoErrors
+import com.chrisjenx.yakcov.onFocusLost
+import com.chrisjenx.yakcov.strings.Email
+import com.chrisjenx.yakcov.strings.MinLength
+import com.chrisjenx.yakcov.strings.Required
+import com.chrisjenx.yakcov.supportingText
+import com.chrisjenx.yakcov.toFieldState
+
+// --8<-- [start:mvi-model]
+// Plain top-level rule lists: shared by reduce() and any unit test, no Compose needed.
+private val emailRules: List<ValueValidatorRule<String>> = listOf(Required, Email)
+private val passwordRules: List<ValueValidatorRule<String>> = listOf(Required, MinLength(8))
+
+// Every field is a val; FieldValidationState is @Immutable, so the Model is value-stable.
+data class SignUpModel(
+    val email: String = "",
+    val emailState: FieldValidationState = FieldValidationState.Pristine,
+    val password: String = "",
+    val passwordState: FieldValidationState = FieldValidationState.Pristine,
+    /** null = not attempted, true = accepted, false = blocked (errors surfaced). */
+    val submitted: Boolean? = null,
+) {
+    /** Driven purely by severity (ignores showError) — live from the first frame. */
+    val canSubmit: Boolean get() = listOf(emailState, passwordState).hasNoErrors()
+}
+
+/** Seed with rules pre-run (showError = false) so canSubmit is honest before any input. */
+fun initialSignUpModel(): SignUpModel = SignUpModel(
+    emailState = emailRules.toFieldState("", showError = false),
+    passwordState = passwordRules.toFieldState("", showError = false),
+)
+
+sealed interface SignUpEvent {
+    data class EmailChanged(val value: String) : SignUpEvent
+    data object EmailFocusLost : SignUpEvent
+    data class PasswordChanged(val value: String) : SignUpEvent
+    data object PasswordFocusLost : SignUpEvent
+    data object Submit : SignUpEvent
+}
+// --8<-- [end:mvi-model]
+
+// --8<-- [start:mvi-reduce]
+// THE pure core: (Model, Event) -> Model. No Compose, no coroutines, no IO.
+// showError is threaded, not recomputed: Changed preserves it; FocusLost/Submit force it true.
+fun reduce(model: SignUpModel, event: SignUpEvent): SignUpModel = when (event) {
+    is SignUpEvent.EmailChanged -> model.copy(
+        email = event.value,
+        emailState = emailRules.toFieldState(event.value, model.emailState.showError),
+        submitted = null,
+    )
+    SignUpEvent.EmailFocusLost -> model.copy(
+        emailState = emailRules.toFieldState(model.email, showError = true),
+    )
+    is SignUpEvent.PasswordChanged -> model.copy(
+        password = event.value,
+        passwordState = passwordRules.toFieldState(event.value, model.passwordState.showError),
+        submitted = null,
+    )
+    SignUpEvent.PasswordFocusLost -> model.copy(
+        passwordState = passwordRules.toFieldState(model.password, showError = true),
+    )
+    SignUpEvent.Submit -> {
+        // Surface errors on every field, then read validity off severity.
+        val surfaced = model.copy(
+            emailState = emailRules.toFieldState(model.email, showError = true),
+            passwordState = passwordRules.toFieldState(model.password, showError = true),
+        )
+        surfaced.copy(submitted = surfaced.canSubmit)
+    }
+}
+// --8<-- [end:mvi-reduce]
+
+// --8<-- [start:mvi-store]
+// Single source of truth + single dispatch entry point. The only Compose-aware piece;
+// swap for a ViewModel + StateFlow without touching reduce/Model/Event.
+@Stable
+class SignUpStore(initial: SignUpModel = initialSignUpModel()) {
+    var model by mutableStateOf(initial)
+        private set
+
+    fun dispatch(event: SignUpEvent) {
+        model = reduce(model, event)
+    }
+}
+// --8<-- [end:mvi-store]
+
+// --8<-- [start:mvi-ui]
+@Composable
+fun MviSignUpScreen(store: SignUpStore = remember { SignUpStore() }) {
+    val model = store.model
+    Column {
+        OutlinedTextField(
+            value = model.email,
+            onValueChange = { store.dispatch(SignUpEvent.EmailChanged(it)) },
+            label = { Text("Email") },
+            isError = model.emailState.isError,
+            supportingText = model.emailState.supportingText(),
+            singleLine = true,
+            modifier = Modifier
+                .fillMaxWidth()
+                .onFocusLost { store.dispatch(SignUpEvent.EmailFocusLost) },
+        )
+        OutlinedTextField(
+            value = model.password,
+            onValueChange = { store.dispatch(SignUpEvent.PasswordChanged(it)) },
+            label = { Text("Password") },
+            isError = model.passwordState.isError,
+            supportingText = model.passwordState.supportingText(),
+            singleLine = true,
+            modifier = Modifier
+                .fillMaxWidth()
+                .onFocusLost { store.dispatch(SignUpEvent.PasswordFocusLost) },
+        )
+        Button(
+            onClick = { store.dispatch(SignUpEvent.Submit) },
+            modifier = Modifier.fillMaxWidth(),
+        ) { Text(if (model.canSubmit) "Create account" else "Fix errors to submit") }
+        model.submitted?.let { Text(if (it) "Valid — proceeding" else "Fix the errors above") }
+    }
+}
+// --8<-- [end:mvi-ui]

--- a/docs-examples/src/commonMain/kotlin/com/chrisjenx/yakcov/docs/recipes/Recipes.kt
+++ b/docs-examples/src/commonMain/kotlin/com/chrisjenx/yakcov/docs/recipes/Recipes.kt
@@ -1,0 +1,57 @@
+package com.chrisjenx.yakcov.docs.recipes
+
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import com.chrisjenx.yakcov.RegularValidationResult
+import com.chrisjenx.yakcov.ValidationResult
+import com.chrisjenx.yakcov.ValueValidatorRule
+import com.chrisjenx.yakcov.strings.Phone
+import com.chrisjenx.yakcov.strings.Required
+import com.chrisjenx.yakcov.strings.rememberTextFieldValueValidator
+
+// --8<-- [start:custom-rule]
+// A reusable rule: an object (or data class for parameterised rules) implementing
+// ValueValidatorRule<V>. Return success for blank input — let Required own emptiness.
+data object UsZipCode : ValueValidatorRule<String> {
+    private val zip = Regex("""^\d{5}(-\d{4})?$""")
+    override fun validate(value: String): ValidationResult {
+        if (value.isBlank()) return RegularValidationResult.success()
+        return if (zip.matches(value)) RegularValidationResult.success()
+        else RegularValidationResult.error("Enter a valid ZIP code")
+    }
+}
+// --8<-- [end:custom-rule]
+
+// --8<-- [start:custom-rule-sam]
+// ValueValidatorRule is a fun interface — one-off rules can be inline SAM lambdas.
+// Severity is graded: error/warning/info/success all flow through supportingText.
+val NoPlusAddressing = ValueValidatorRule<String> { value ->
+    if ("+" in value) RegularValidationResult.warning("Plus-addressing may break receipts")
+    else RegularValidationResult.success()
+}
+// --8<-- [end:custom-rule-sam]
+
+// --8<-- [start:phone]
+@Composable
+fun PhoneField() {
+    // Phone(defaultRegion) is powered by libphonenumber-kotlin, which yakcov declares
+    // compileOnly — your app must add the dependency (see this page's install section).
+    val phone = rememberTextFieldValueValidator(rules = listOf(Required, Phone("US")))
+    with(phone) {
+        OutlinedTextField(
+            value = value,
+            onValueChange = ::onValueChange,
+            label = { Text("Phone") },
+            isError = isError(),
+            supportingText = supportingText(),
+            singleLine = true,
+            modifier = Modifier
+                .fillMaxWidth()
+                .validationConfig(validateOnFocusLost = true),
+        )
+    }
+}
+// --8<-- [end:phone]

--- a/docs-examples/src/commonMain/kotlin/com/chrisjenx/yakcov/docs/viewmodel/ViewModelExample.kt
+++ b/docs-examples/src/commonMain/kotlin/com/chrisjenx/yakcov/docs/viewmodel/ViewModelExample.kt
@@ -44,12 +44,16 @@ class SignUpViewModel : ViewModel() {
 
 // --8<-- [start:vm-ui]
 @Composable
-fun SignUpScreen(viewModel: SignUpViewModel = viewModel { SignUpViewModel() }) {
+fun SignUpScreen(
+    onSubmit: () -> Unit,
+    viewModel: SignUpViewModel = viewModel { SignUpViewModel() },
+) {
     Column {
         ValidatedField(viewModel.email, label = "Email")
         ValidatedField(viewModel.password, label = "Password")
         Button(
-            onClick = { viewModel.submit() },
+            // submit() surfaces errors on every field and returns true only when all pass.
+            onClick = { if (viewModel.submit()) onSubmit() },
             modifier = Modifier.fillMaxWidth(),
         ) { Text("Create account") }
     }

--- a/docs-examples/src/commonMain/kotlin/com/chrisjenx/yakcov/docs/viewmodel/ViewModelExample.kt
+++ b/docs-examples/src/commonMain/kotlin/com/chrisjenx/yakcov/docs/viewmodel/ViewModelExample.kt
@@ -1,0 +1,165 @@
+package com.chrisjenx.yakcov.docs.viewmodel
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material3.Button
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewmodel.compose.viewModel
+import com.chrisjenx.yakcov.FieldValidationState
+import com.chrisjenx.yakcov.FieldValidator
+import com.chrisjenx.yakcov.hasNoErrors
+import com.chrisjenx.yakcov.onFocusLost
+import com.chrisjenx.yakcov.strings.Email
+import com.chrisjenx.yakcov.strings.MinLength
+import com.chrisjenx.yakcov.strings.Required
+import com.chrisjenx.yakcov.supportingText
+import com.chrisjenx.yakcov.toFieldState
+import com.chrisjenx.yakcov.validate
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.flow.updateAndGet
+
+/* ===== Recommended wiring: the validator LIVES IN the ViewModel ===== */
+
+// --8<-- [start:vm]
+class SignUpViewModel : ViewModel() {
+    // FieldValidator has a plain (non-@Composable) constructor — safe to own in a
+    // ViewModel. It is snapshot-state backed, so composables reading value/state
+    // recompose automatically, and it survives configuration changes with the VM.
+    val email = FieldValidator("", rules = listOf(Required, Email))
+    val password = FieldValidator("", rules = listOf(Required, MinLength(8)))
+
+    /** Form-level submit: shows errors on every field, true when all pass. Unit-testable without UI. */
+    fun submit(): Boolean = listOf(email, password).validate()
+}
+// --8<-- [end:vm]
+
+// --8<-- [start:vm-ui]
+@Composable
+fun SignUpScreen(viewModel: SignUpViewModel = viewModel { SignUpViewModel() }) {
+    Column {
+        ValidatedField(viewModel.email, label = "Email")
+        ValidatedField(viewModel.password, label = "Password")
+        Button(
+            onClick = { viewModel.submit() },
+            modifier = Modifier.fillMaxWidth(),
+        ) { Text("Create account") }
+    }
+}
+
+// The @Composable rendering helpers are called HERE, in composition — never in the
+// ViewModel. isError is a plain property; supportingText() resolves string resources.
+@Composable
+private fun ValidatedField(field: FieldValidator<String>, label: String) {
+    OutlinedTextField(
+        value = field.value,
+        onValueChange = field::onValueChange,
+        label = { Text(label) },
+        isError = field.state.isError,
+        supportingText = field.state.supportingText(),
+        singleLine = true,
+        modifier = Modifier
+            .fillMaxWidth()
+            .onFocusLost { field.onFocusLost() },
+    )
+}
+// --8<-- [end:vm-ui]
+
+/* ===== Alternative wiring: value-hoist — immutable UiState, validator logic stays pure ===== */
+
+// --8<-- [start:vm-hoist]
+private val emailRules = listOf(Required, Email)
+private val passwordRules = listOf(Required, MinLength(8))
+
+data class SignUpUiState(
+    val email: String = "",
+    val emailState: FieldValidationState = FieldValidationState.Pristine,
+    val password: String = "",
+    val passwordState: FieldValidationState = FieldValidationState.Pristine,
+) {
+    val canSubmit: Boolean get() = listOf(emailState, passwordState).hasNoErrors()
+}
+
+class HoistedSignUpViewModel : ViewModel() {
+    private val _state = MutableStateFlow(
+        // Seed by folding the rules with showError = false so canSubmit is honest
+        // before any input (a pristine required field must not look submittable).
+        SignUpUiState(
+            emailState = emailRules.toFieldState("", showError = false),
+            passwordState = passwordRules.toFieldState("", showError = false),
+        )
+    )
+    val state: StateFlow<SignUpUiState> = _state.asStateFlow()
+
+    fun onEmailChange(value: String) = _state.update {
+        // Recompute severity on every keystroke, but PRESERVE showError so no
+        // error pops while the user is still typing.
+        it.copy(email = value, emailState = emailRules.toFieldState(value, it.emailState.showError))
+    }
+
+    fun onEmailFocusLost() = _state.update {
+        it.copy(emailState = emailRules.toFieldState(it.email, showError = true))
+    }
+
+    fun onPasswordChange(value: String) = _state.update {
+        it.copy(password = value, passwordState = passwordRules.toFieldState(value, it.passwordState.showError))
+    }
+
+    fun onPasswordFocusLost() = _state.update {
+        it.copy(passwordState = passwordRules.toFieldState(it.password, showError = true))
+    }
+
+    /** Submit: force errors visible on all fields, then read validity off severity. */
+    fun submit(): Boolean = _state.updateAndGet {
+        it.copy(
+            emailState = emailRules.toFieldState(it.email, showError = true),
+            passwordState = passwordRules.toFieldState(it.password, showError = true),
+        )
+    }.canSubmit
+}
+// --8<-- [end:vm-hoist]
+
+// --8<-- [start:vm-hoist-ui]
+@Composable
+fun HoistedSignUpScreen(
+    viewModel: HoistedSignUpViewModel = viewModel { HoistedSignUpViewModel() },
+) {
+    val state by viewModel.state.collectAsState()
+    Column {
+        OutlinedTextField(
+            value = state.email,
+            onValueChange = viewModel::onEmailChange,
+            label = { Text("Email") },
+            isError = state.emailState.isError,
+            supportingText = state.emailState.supportingText(),
+            singleLine = true,
+            modifier = Modifier
+                .fillMaxWidth()
+                .onFocusLost(viewModel::onEmailFocusLost),
+        )
+        OutlinedTextField(
+            value = state.password,
+            onValueChange = viewModel::onPasswordChange,
+            label = { Text("Password") },
+            isError = state.passwordState.isError,
+            supportingText = state.passwordState.supportingText(),
+            singleLine = true,
+            modifier = Modifier
+                .fillMaxWidth()
+                .onFocusLost(viewModel::onPasswordFocusLost),
+        )
+        Button(
+            onClick = { viewModel.submit() },
+            modifier = Modifier.fillMaxWidth(),
+        ) { Text(if (state.canSubmit) "Create account" else "Fix errors to submit") }
+    }
+}
+// --8<-- [end:vm-hoist-ui]

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -53,8 +53,12 @@ modifier = Modifier.validationConfig(
 )
 ```
 
-For headless `FieldValidator`s, call `field.onFocusLost()` from
-`Modifier.onFocusLost { ... }` instead — same behavior, state-holder owned.
+For headless `FieldValidator`s there's no `validationConfig` modifier; call
+`field.onFocusLost()` from `Modifier.onFocusLost { ... }` to validate-on-focus-lost,
+state-holder owned. The `shakeOnInvalid` / `showErrorOnInteraction` knobs are specific to
+the in-composition validators — on the headless path, drive shake yourself (see
+[MVI](patterns/mvi.md)) and gate error display via the `showError` flag you thread
+through `toFieldState`.
 
 ## Form-level submit
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,75 @@
+# Getting started
+
+## Rules
+
+Validation is composed from `ValueValidatorRule`s. Built-ins cover the common cases —
+`Required`, `Email`, `MinLength(n)`, `MaxLength(n)`, `Phone(region)` (see
+[phone validation](recipes/phone.md)), and more in
+`com.chrisjenx.yakcov.strings` / `com.chrisjenx.yakcov.generic`.
+
+`ValueValidatorRule` is a `fun interface`, so one-off rules are a lambda away:
+
+```kotlin
+--8<-- "docs-examples/src/commonMain/kotlin/com/chrisjenx/yakcov/docs/recipes/Recipes.kt:custom-rule-sam"
+```
+
+See [custom rules](recipes/custom-rules.md) for reusable rule types and severity grading.
+
+## Two validator families
+
+| | In-composition | State-holder-owned (headless) |
+|---|---|---|
+| **Create with** | `rememberTextFieldValueValidator(rules)` / `rememberGenericValueValidator(state, rules)` | `FieldValidator(initial, rules)` — plain constructor |
+| **Choose when** | The form has no state holder; everything lives in the composable | A ViewModel/presenter owns form state; you want `submit()` testable without UI |
+
+Both are snapshot-state backed, so composables that read them recompose automatically.
+The pattern guides ([ViewModel](patterns/viewmodel.md), [MVI](patterns/mvi.md),
+[Circuit](patterns/circuit.md)) show which to reach for in each architecture.
+
+## Showing errors
+
+Validation severity and error *display* are separate channels: rules compute a severity
+on every change, but nothing is shown until the validator decides errors should be
+visible (focus lost, submit, …). That's why nothing flashes red while the user is still
+typing.
+
+- `isError()` / `FieldValidationState.isError` — true once errors are shown **and**
+  severity is `ERROR`
+- `supportingText()` — a ready-made slot value for Material `TextField`s; renders the
+  most severe message, or `null` when nothing should show
+- `Outcome` severities: `ERROR` > `WARNING` > `INFO` > `SUCCESS`. Warnings and info
+  messages flow through the same display channel without blocking submission.
+
+## validationConfig
+
+For in-composition validators, the `validationConfig` modifier wires interaction
+behavior:
+
+```kotlin
+modifier = Modifier.validationConfig(
+    validateOnFocusLost = true,       // start validating when focus leaves the field
+    shakeOnInvalid = true,            // shake the field when validate() fails
+    showErrorOnInteraction = false,   // defer isError until validate() is called
+)
+```
+
+For headless `FieldValidator`s, call `field.onFocusLost()` from
+`Modifier.onFocusLost { ... }` instead — same behavior, state-holder owned.
+
+## Form-level submit
+
+Validate everything at once; errors surface on every field and the call tells you
+whether to proceed:
+
+```kotlin
+if (listOf(email, password).validate()) { /* all valid — submit */ }
+```
+
+Works on both families: `List<ValueValidator<*, *>>.validate()` and
+`List<FieldValidator<*>>.validate()`.
+
+## A complete screen
+
+```kotlin
+--8<-- "docs-examples/src/commonMain/kotlin/com/chrisjenx/yakcov/docs/basic/BasicScreen.kt:basic"
+```

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,44 @@
+# Yakcov
+
+**Y**et **A**nother **K**otlin **CO**mpose **V**alidation library.
+
+Yakcov makes `TextField` (and any other input) validation painless in Compose
+Multiplatform. Validators are backed by Compose snapshot state, so your UI reacts
+automatically; validation outcomes are severity-ranked (`ERROR`, `WARNING`, `INFO`,
+`SUCCESS`); and the same rules run on **Android, JVM, JS, Wasm, and iOS**.
+
+!!! tip "These docs can't lie"
+    Every code block on this site is pulled from the
+    [`docs-examples`](https://github.com/chrisjenx/yakcov/tree/main/docs-examples)
+    module, which compiles in CI against the current library API. If an example
+    here stopped working, the build would fail before the docs could ship.
+
+## Install
+
+Yakcov publishes all targets to
+[Maven Central](https://central.sonatype.com/artifact/com.chrisjenx.yakcov/library) —
+add the common artifact and Gradle resolves the right target per platform:
+
+```kotlin
+commonMain {
+    dependencies {
+        implementation("com.chrisjenx.yakcov:library:${version}")
+    }
+}
+```
+
+## Yakcov in 30 seconds
+
+```kotlin
+--8<-- "docs-examples/src/commonMain/kotlin/com/chrisjenx/yakcov/docs/basic/BasicScreen.kt:basic"
+```
+
+## Where next
+
+- [Getting started](getting-started.md) — rules, error display, `validationConfig`, form-level submit
+- Pattern guides, each showing **all the layers** (UI, state holder, validation wiring):
+    - [Basic screen](patterns/basic.md) — no state holder
+    - [ViewModel](patterns/viewmodel.md) — validator owned by the ViewModel
+    - [MVI / UDF](patterns/mvi.md) — pure reducer, immutable model
+    - [Circuit](patterns/circuit.md) — validator owned by the presenter
+- Recipes: [custom rules](recipes/custom-rules.md), [phone validation](recipes/phone.md)

--- a/docs/patterns/basic.md
+++ b/docs/patterns/basic.md
@@ -1,0 +1,23 @@
+# Basic screen
+
+**When to use:** quick forms and screens with no state holder — the validators live
+directly in the composable.
+
+```kotlin
+--8<-- "docs-examples/src/commonMain/kotlin/com/chrisjenx/yakcov/docs/basic/BasicScreen.kt:basic"
+```
+
+How the wiring works:
+
+- `rememberTextFieldValueValidator` keeps each validator across recompositions. The
+  validator owns the field's `TextFieldValue` draft *and* its validation state — no
+  separate `mutableStateOf` needed.
+- `Modifier.validationConfig(validateOnFocusLost = true, shakeOnInvalid = true)` starts
+  validation when the user leaves the field and shakes it when a submit finds it
+  invalid. Nothing turns red while they're still typing.
+- The submit button gates on `listOf(email, password).validate()` — this surfaces
+  errors on **every** field (including ones the user never touched) and returns `true`
+  only when all rules pass.
+
+When the form grows a real state holder, graduate to the
+[ViewModel](viewmodel.md), [MVI](mvi.md), or [Circuit](circuit.md) wiring.

--- a/docs/patterns/circuit.md
+++ b/docs/patterns/circuit.md
@@ -1,0 +1,42 @@
+# Circuit
+
+**Recommended wiring: the validator lives in the presenter.**
+[Circuit](https://slackhq.github.io/circuit/) presenters are composable functions, so
+`remember { FieldValidator(...) }` works there naturally — the presenter owns the form
+state, and the UI stays a dumb renderer of `CircuitUiState`.
+
+## State and events
+
+```kotlin
+--8<-- "docs-examples/src/commonMain/kotlin/com/chrisjenx/yakcov/docs/circuit/CircuitExample.kt:circuit-state"
+```
+
+## The presenter
+
+```kotlin
+--8<-- "docs-examples/src/commonMain/kotlin/com/chrisjenx/yakcov/docs/circuit/CircuitExample.kt:circuit-presenter"
+```
+
+## The UI
+
+```kotlin
+--8<-- "docs-examples/src/commonMain/kotlin/com/chrisjenx/yakcov/docs/circuit/CircuitExample.kt:circuit-ui"
+```
+
+## Hosting it
+
+```kotlin
+--8<-- "docs-examples/src/commonMain/kotlin/com/chrisjenx/yakcov/docs/circuit/CircuitExample.kt:circuit-host"
+```
+
+!!! note "What this example leaves out"
+    A real app routes via a `Screen` + `CircuitContent`, registering the presenter and
+    UI through `Presenter.Factory` / `Ui.Factory`. `Screen` is `Parcelable` on Android
+    (`@Parcelize` plumbing), which is app-level wiring unrelated to validation — so the
+    example hosts the presenter directly. Only `circuit-foundation` is needed for
+    everything shown here, and `rememberRetained` is a drop-in upgrade for `remember`
+    if you want the validators to survive Circuit's retention scope.
+
+Prefer immutable state throughout? The [MVI value-hoist wiring](mvi.md) drops into a
+Circuit presenter unchanged — fold rules with `toFieldState` and put
+`FieldValidationState` in your `CircuitUiState` instead of the validator.

--- a/docs/patterns/mvi.md
+++ b/docs/patterns/mvi.md
@@ -1,0 +1,45 @@
+# MVI / UDF
+
+**Recommended wiring: value-hoist.** A reducer's contract is `(Model, Event) -> Model`
+with an immutable model — owning a *mutable* validator inside that model fights the
+pattern (and `FieldValidator`'s own docs forbid it). Instead, hoist the raw value and
+fold the rules with the pure `toFieldState(value, showError)` helpers; the immutable
+`FieldValidationState` rides in the model like any other value.
+
+## Model and events
+
+```kotlin
+--8<-- "docs-examples/src/commonMain/kotlin/com/chrisjenx/yakcov/docs/mvi/MviExample.kt:mvi-model"
+```
+
+## The reducer
+
+```kotlin
+--8<-- "docs-examples/src/commonMain/kotlin/com/chrisjenx/yakcov/docs/mvi/MviExample.kt:mvi-reduce"
+```
+
+## The store
+
+```kotlin
+--8<-- "docs-examples/src/commonMain/kotlin/com/chrisjenx/yakcov/docs/mvi/MviExample.kt:mvi-store"
+```
+
+## The UI
+
+```kotlin
+--8<-- "docs-examples/src/commonMain/kotlin/com/chrisjenx/yakcov/docs/mvi/MviExample.kt:mvi-ui"
+```
+
+Notes on the wiring:
+
+- **`showError` is threaded, not recomputed.** `Changed` events preserve the current
+  `showError` (severity updates silently while typing); `FocusLost` and `Submit` force
+  it `true`. This reproduces the "don't flash red mid-keystroke" behavior the
+  in-composition validators give you for free.
+- **The reducer is plain Kotlin** — no Compose, no coroutines — so
+  `reduce(model, Submit)` is trivially unit-testable.
+- **The store is swappable.** Replace `SignUpStore` with a ViewModel exposing a
+  `StateFlow<SignUpModel>` (or your MVI framework's container) without touching
+  `reduce`, the model, or the events.
+- Cross-field rules (confirm-password, etc.) are SAM lambdas closing over the model —
+  see [custom rules](../recipes/custom-rules.md).

--- a/docs/patterns/mvi.md
+++ b/docs/patterns/mvi.md
@@ -42,4 +42,18 @@ Notes on the wiring:
   `StateFlow<SignUpModel>` (or your MVI framework's container) without touching
   `reduce`, the model, or the events.
 - Cross-field rules (confirm-password, etc.) are SAM lambdas closing over the model —
-  see [custom rules](../recipes/custom-rules.md).
+  see [custom rules](../recipes/custom-rules.md). The built-in `PasswordMatches` couples
+  to a *mutable* validator and does **not** fit a reducer.
+- **Shake stays UI-owned:** keep a `rememberShakingState()` in the screen and call
+  `shakingState.shake()` when an invalid submit reduces `submitted` to `false`.
+
+## Persistence & process death
+
+`FieldValidationState` is `@Immutable @Serializable` — `severity` + `showError`
+persist, the message (`result`) is `@Transient` and recomputes. Persist the drafts plus
+each field's `showError` with `rememberSaveable` (a `FieldValidationState.Saver` is
+provided), then **rehydrate on restore by re-running the rules through `toFieldState`**
+so the message reappears with `showError` preserved. For cross-process JSON, add a
+kotlinx-serialization runtime and encode `FieldValidationState` directly (it persists
+`Outcome` by constant name). See the runnable, process-death-surviving version in
+[`MviSample.kt`](https://github.com/chrisjenx/yakcov/blob/main/sample/src/main/java/com/chrisjenx/yakcov/sample/MviSample.kt).

--- a/docs/patterns/viewmodel.md
+++ b/docs/patterns/viewmodel.md
@@ -40,6 +40,14 @@ the ViewModel pure at the cost of more plumbing per field.
     `remember`). Don't construct it inside a recomposing body and don't copy it — both
     reset its validation state.
 
+!!! note "Reformatting fields keep the cursor"
+    The `ValidatedField` binder above uses the plain `String` overload of
+    `OutlinedTextField` for brevity. For fields that **reformat** as the user types
+    (currency, phone), bind a local `TextFieldValue` and push only `.text` to
+    `field.onValueChange`, so the cursor/selection survives the reformat — otherwise the
+    caret jumps to the end on every keystroke. See `ValidatedTextField` in the
+    [PresenterSample](https://github.com/chrisjenx/yakcov/blob/main/sample/src/main/java/com/chrisjenx/yakcov/sample/PresenterSample.kt).
+
 ## Observability
 
 `FieldValidator` takes an optional `observer` — a `FieldValidatorObserver` fired after

--- a/docs/patterns/viewmodel.md
+++ b/docs/patterns/viewmodel.md
@@ -34,3 +34,26 @@ the ViewModel pure at the cost of more plumbing per field.
     is a plain property the VM *can* read; `supportingText()` resolves string resources
     and must be called from the UI, in composition. Keep severity logic in the state
     holder and rendering in the composable.
+
+!!! warning "Construct once, never copy"
+    Construct a `FieldValidator` **once** and hold it (a VM/presenter field, DI, or
+    `remember`). Don't construct it inside a recomposing body and don't copy it — both
+    reset its validation state.
+
+## Observability
+
+`FieldValidator` takes an optional `observer` — a `FieldValidatorObserver` fired after
+every mutation commits (`ValueChanged` / `Validated` / `Reset`) with the post-mutation
+value + state. Handy for analytics, logging, or driving UI like the sample's live
+state-flow visualizer
+([`StateFlowSample.kt`](https://github.com/chrisjenx/yakcov/blob/main/sample/src/main/java/com/chrisjenx/yakcov/sample/StateFlowSample.kt)).
+No event fires at construction; observers must not throw.
+
+On restore-from-persistence, prefer `FieldValidator(initial = restoredDraft, rules,
+initialValidate = true)` over calling `validate()` — it re-runs the rules without
+emitting a `Validated` event an analytics tap would over-count.
+
+!!! info "Unit-testing presenters"
+    If presenter/VM unit tests construct `FieldValidator` or read `.value`/`.state`,
+    add `org.jetbrains.compose:runtime` to the test source set — it is not pulled in
+    transitively.

--- a/docs/patterns/viewmodel.md
+++ b/docs/patterns/viewmodel.md
@@ -1,0 +1,36 @@
+# ViewModel
+
+**Recommended wiring: the validator lives in the ViewModel.** `FieldValidator` has a
+plain constructor and is snapshot-state backed, which means it works *outside*
+composition: own it in the VM and the form state survives configuration changes,
+`submit()` is unit-testable with no Compose UI, and any composable reading
+`field.value`/`field.state` still recomposes automatically.
+
+If your team's convention is strictly-immutable UI state, the value-hoist wiring keeps
+the ViewModel pure at the cost of more plumbing per field.
+
+=== "Validator in the ViewModel (recommended)"
+
+    ```kotlin
+    --8<-- "docs-examples/src/commonMain/kotlin/com/chrisjenx/yakcov/docs/viewmodel/ViewModelExample.kt:vm"
+    ```
+
+    ```kotlin
+    --8<-- "docs-examples/src/commonMain/kotlin/com/chrisjenx/yakcov/docs/viewmodel/ViewModelExample.kt:vm-ui"
+    ```
+
+=== "Value-hoist (immutable UiState)"
+
+    ```kotlin
+    --8<-- "docs-examples/src/commonMain/kotlin/com/chrisjenx/yakcov/docs/viewmodel/ViewModelExample.kt:vm-hoist"
+    ```
+
+    ```kotlin
+    --8<-- "docs-examples/src/commonMain/kotlin/com/chrisjenx/yakcov/docs/viewmodel/ViewModelExample.kt:vm-hoist-ui"
+    ```
+
+!!! note "The @Composable boundary"
+    The ViewModel never calls the `@Composable` rendering helpers. `field.state.isError`
+    is a plain property the VM *can* read; `supportingText()` resolves string resources
+    and must be called from the UI, in composition. Keep severity logic in the state
+    holder and rendering in the composable.

--- a/docs/recipes/custom-rules.md
+++ b/docs/recipes/custom-rules.md
@@ -1,0 +1,39 @@
+# Custom rules
+
+A rule is anything implementing `ValueValidatorRule<V>` — return a `ValidationResult`
+from `validate(value)`.
+
+## Reusable rule types
+
+```kotlin
+--8<-- "docs-examples/src/commonMain/kotlin/com/chrisjenx/yakcov/docs/recipes/Recipes.kt:custom-rule"
+```
+
+Use a `data class` instead of `data object` when the rule takes parameters
+(`MinLength(minLength = 8)` is built that way).
+
+## One-off rules (SAM lambdas)
+
+```kotlin
+--8<-- "docs-examples/src/commonMain/kotlin/com/chrisjenx/yakcov/docs/recipes/Recipes.kt:custom-rule-sam"
+```
+
+## Severities and results
+
+`ValidationResult.outcome()` ranks `ERROR` > `WARNING` > `INFO` > `SUCCESS`. Only
+`ERROR` blocks `validate()`/submission — warnings and info messages display through
+`supportingText` without failing the field.
+
+Two result implementations ship with the library:
+
+- `RegularValidationResult.error/warning/info/success("message")` — plain strings,
+  shown verbatim
+- `ResourceValidationResult` — backed by Compose `StringResource` for i18n; all the
+  built-in rules use this
+
+## Conventions
+
+- **Return success for blank input** and let `Required` own emptiness — that way every
+  rule composes with optional fields (`listOf(UsZipCode)` allows blank,
+  `listOf(Required, UsZipCode)` doesn't).
+- Rules run on **every value change**; keep `validate` cheap and side-effect free.

--- a/docs/recipes/phone.md
+++ b/docs/recipes/phone.md
@@ -1,0 +1,28 @@
+# Phone validation
+
+The `Phone` rule validates numbers with
+[libphonenumber-kotlin](https://github.com/luca992/libphonenumber-kotlin)
+(luca992's multiplatform port of Google's libphonenumber).
+
+```kotlin
+--8<-- "docs-examples/src/commonMain/kotlin/com/chrisjenx/yakcov/docs/recipes/Recipes.kt:phone"
+```
+
+`Phone` also accepts a `State<String>` for the region, so the default region can react
+to a country picker: `Phone(defaultRegion = countryState)`.
+
+## Install (required)
+
+Yakcov declares libphonenumber-kotlin as `compileOnly`, so phone rules need your app
+(or shared module) to provide the dependency:
+
+```kotlin
+commonMain {
+    dependencies {
+        implementation("io.github.luca992.libphonenumber-kotlin:libphonenumber:0.1.9")
+    }
+}
+```
+
+Without it, using `Phone` fails at runtime with a missing-class error — everything else
+in Yakcov works without the dependency.

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,6 +2,7 @@
 agp = "8.12.3"
 androidx-activityCompose = "1.13.0"
 androidx-uiTest = "1.11.2"
+circuit = "0.33.1"
 # https://github.com/JetBrains/compose-multiplatform/releases
 compose = "1.11.1"
 compose-material3 = "1.11.0-alpha07"
@@ -9,6 +10,8 @@ compose-material3 = "1.11.0-alpha07"
 composeBom = "2026.05.01"
 # androidx.core 1.19.0 requires AGP 9.1+ / compileSdk 37; capped at 1.17.0 until the AGP 9 upgrade
 coreKtx = "1.17.0"
+# org.jetbrains.androidx.lifecycle KMP artifacts (desktop + android), used by docs-examples
+jetbrains-lifecycle = "2.10.0"
 # Compose Multiplatform 1.11 requires Kotlin >= 2.3.10 for native/web targets
 kotlin = "2.3.21"
 kotlinx-datetime = "0.8.0"
@@ -27,12 +30,14 @@ androidx-material-icons-core = { group = "androidx.compose.material", name = "ma
 androidx-startup-runtime = { module = "androidx.startup:startup-runtime", version.ref = "startupRuntime" }
 androidx-testManifest = { module = "androidx.compose.ui:ui-test-manifest", version.ref = "androidx-uiTest" }
 androidx-ui = { group = "androidx.compose.ui", name = "ui" }
+circuit-foundation = { module = "com.slack.circuit:circuit-foundation", version.ref = "circuit" }
 androidx-ui-graphics = { group = "androidx.compose.ui", name = "ui-graphics" }
 androidx-ui-tooling = { group = "androidx.compose.ui", name = "ui-tooling" }
 androidx-ui-tooling-preview = { group = "androidx.compose.ui", name = "ui-tooling-preview" }
 jetbrains-compose-components-resources = { group = "org.jetbrains.compose.components", name = "components-resources", version.ref = "compose" }
 jetbrains-compose-foundation = { group = "org.jetbrains.compose.foundation", name = "foundation", version.ref = "compose" }
 jetbrains-compose-html-core = { group = "org.jetbrains.compose.html", name = "html-core", version.ref = "compose" }
+jetbrains-lifecycle-viewmodel-compose = { group = "org.jetbrains.androidx.lifecycle", name = "lifecycle-viewmodel-compose", version.ref = "jetbrains-lifecycle" }
 jetbrains-compose-material3 = { group = "org.jetbrains.compose.material3", name = "material3", version.ref = "compose-material3" }
 jetbrains-compose-runtime = { group = "org.jetbrains.compose.runtime", name = "runtime", version.ref = "compose" }
 jetbrains-compose-ui-test = { group = "org.jetbrains.compose.ui", name = "ui-test", version.ref = "compose" }

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,53 @@
+site_name: Yakcov
+site_description: Yet Another Kotlin COmpose Validation library
+site_url: https://chrisjenx.github.io/yakcov/
+repo_url: https://github.com/chrisjenx/yakcov
+repo_name: chrisjenx/yakcov
+edit_uri: edit/main/docs/
+
+# Local-only superpowers specs (gitignored) must never reach the site
+exclude_docs: |
+  superpowers/
+
+theme:
+  name: material
+  features:
+    - navigation.sections
+    - navigation.top
+    - content.code.copy
+    - content.tabs.link
+  palette:
+    - media: "(prefers-color-scheme: light)"
+      scheme: default
+      toggle:
+        icon: material/brightness-7
+        name: Switch to dark mode
+    - media: "(prefers-color-scheme: dark)"
+      scheme: slate
+      toggle:
+        icon: material/brightness-4
+        name: Switch to light mode
+
+markdown_extensions:
+  - admonition
+  - pymdownx.highlight:
+      anchor_linenums: true
+  - pymdownx.inlinehilite
+  - pymdownx.superfences
+  - pymdownx.tabbed:
+      alternate_style: true
+  - pymdownx.snippets:
+      base_path: ['.']
+      check_paths: true
+
+nav:
+  - Home: index.md
+  - Getting Started: getting-started.md
+  - Patterns:
+      - Basic screen: patterns/basic.md
+      - ViewModel: patterns/viewmodel.md
+      - MVI / UDF: patterns/mvi.md
+      - Circuit: patterns/circuit.md
+  - Recipes:
+      - Custom rules: recipes/custom-rules.md
+      - Phone validation: recipes/phone.md

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -20,3 +20,4 @@ dependencyResolutionManagement {
 
 include(":library")
 include(":sample")
+include(":docs-examples")


### PR DESCRIPTION
Closes #17

## What

MkDocs Material docs site (deployed to GitHub Pages) showing yakcov wired through common UI patterns — **basic screen, ViewModel, MVI/UDF, and Circuit** — each with all layers visible (UI, state holder, validation wiring).

**Every code block on the site is compiled.** Examples live in a new `docs-examples` module (KMP, jvm + androidTarget only, **intentionally unpublished** — no publishing plugin, untouched by the release scripts) and are pulled into the Markdown via `pymdownx.snippets` named markers. Two guards keep the docs honest:

- `Checks-Jvm` now also runs `:docs-examples:compileDebugKotlinAndroid :docs-examples:compileKotlinJvm` — an API change that breaks an example fails CI.
- The Docs workflow runs `mkdocs build --strict` with `check_paths: true` — a renamed/missing snippet section fails the deploy (verified with a negative test).

## Per-pattern wiring recommendations

| Pattern | Recommended | Page |
|---|---|---|
| Basic screen | validator remembered in the composable | `patterns/basic` |
| ViewModel | **validator lives in the VM** (value-hoist shown as alternative tab) | `patterns/viewmodel` |
| MVI / UDF | **value-hoist** — pure reducer + `toFieldState` folds | `patterns/mvi` |
| Circuit | **validator in the presenter** (presenters are composable) | `patterns/circuit` |

Plus recipes (custom rules, phone/libphonenumber) and a getting-started guide. README trimmed to point at the site; the headless deep-dive content (observer, persistence/process-death) moved into the ViewModel/MVI pages.

## New dependencies (docs-examples only)

- `com.slack.circuit:circuit-foundation:0.33.1`
- `org.jetbrains.androidx.lifecycle:lifecycle-viewmodel-compose:2.10.0`

## ⚠️ One-time manual step after merge

After the first Docs workflow run creates the `gh-pages` branch:
**Settings → Pages → Source = `gh-pages` branch** — the site then publishes at https://chrisjenx.github.io/yakcov/

## Notes

- Dokka API reference deliberately deferred → #21
- `docs-examples` has no iOS/JS/Wasm targets (the wiring patterns are target-agnostic; JVM+Android proves compilation without stressing the build)

🤖 Generated with [Claude Code](https://claude.com/claude-code)