### PR TITLE
ci: re-enable [next] channel targeting Compose 1.12.0-alpha01

### DIFF
--- a/compose-releases.toml
+++ b/compose-releases.toml
@@ -21,12 +21,14 @@ compose-material3 = "1.11.0-alpha07"
 # Xcode 26.3 is installed on the macos-latest runner and links cleanly. Do not remove.
 xcode = "26.3"
 
-# The [next] (beta) channel is retired for now: Compose 1.11 has shipped (it is the
-# stable channel above) and there is no 1.11.x pre-release ahead of it to track.
-# Re-enable when you want to ride the next development line (e.g. Compose 1.12):
-# [next]
-# track = "prerelease"
-# compose = "1.12.0-alpha01"
-# compose-material3 = "1.12.0-alpha01"
-# kotlin = "2.4.0"
-# xcode = "26.3"
+# The [next] (beta) channel rides the next Compose development line ahead of stable.
+# Its CI matrix leg is continue-on-error (keyed on channel == "next" in checks.yml),
+# so a broken pre-release surfaces without blocking the CI-Gate / merges.
+[next]
+track = "prerelease"
+compose = "1.12.0-alpha01"
+compose-material3 = "1.12.0-alpha01"
+# Compose 1.12 bundles the compose-compiler with Kotlin 2.4.0 (latest GA); the
+# release/CI patch rewrites `kotlin` in libs.versions.toml for this channel only.
+kotlin = "2.4.0"
+xcode = "26.3"


### PR DESCRIPTION
## What

Re-activates the retired `[next]` pre-release channel in `compose-releases.toml` to ride the Compose Multiplatform 1.12 development line.

| key | value |
|---|---|
| `compose` | `1.12.0-alpha01` |
| `compose-material3` | `1.12.0-alpha01` |
| `kotlin` | `2.4.0` |
| `track` | `prerelease` |
| `xcode` | `26.3` |

## Why now

`1.12.0-alpha01` has shipped — it's the current `latest`/`release` marker on Maven Central for both the Compose Gradle plugin and material3. The channel was retired only because no 1.11.x pre-release existed ahead of stable; now there is a 1.12 line to track.

## Validation (local, before this PR)

- `./scripts/test-release-logic.sh` → 17/17 pass; `[next]` patches compose/material3/kotlin correctly and restores cleanly.
- `python3 scripts/check-compose-updates.py --self-test` → 47/47 pass.
- `python3 scripts/check-compose-updates.py --check` → `[next]` reported up-to-date at 1.12.0-alpha01 / Kotlin 2.4.0, exit 0.
- `./scripts/lib-release.sh --json-matrix` now emits both `stable` and `next` legs.

## What this PR is *for*

Letting the **Checks matrix actually build the 1.12 leg.** The `next` leg is `continue-on-error` (keyed on `channel == "next"` in `checks.yml`), so if `1.12.0-alpha01` + Kotlin `2.4.0` doesn't build, it surfaces here **without blocking `CI-Gate` or merges**.

## Note on the Kotlin pin

The 1.12.0-alpha01 release notes don't state a required Kotlin version, so `2.4.0` (latest GA, bundles the 1.12 compose-compiler) is pinned manually. The tracker flags this: *"Could not determine Kotlin for 1.12.0-alpha01 — keeping 2.4.0; verify manually."* The next CI leg is that verification. If a leg fails on a Kotlin mismatch, bump/adjust the `kotlin` value here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)