### PR TITLE
build: AGP 9.1.1 / Gradle 9.3.1 / compileSdk 37 (unblock Compose 1.12)

### DIFF
--- a/docs-examples/build.gradle.kts
+++ b/docs-examples/build.gradle.kts
@@ -53,7 +53,7 @@ kotlin {
 
 android {
     namespace = "com.chrisjenx.yakcov.docs"
-    compileSdk = 36
+    compileSdk = 37
     defaultConfig {
         minSdk = 23
     }

--- a/gradle.properties
+++ b/gradle.properties
@@ -11,6 +11,12 @@ kotlin.code.style=official
 #Android
 android.useAndroidX=true
 android.nonTransitiveRClass=true
+# AGP 9 made `com.android.library` incompatible with the kotlin-multiplatform plugin and
+# turned on built-in Kotlin + a new DSL by default. The KMP modules (:library, :docs-examples)
+# still apply `com.android.library` + `androidTarget {}`, so opt back out until they are
+# migrated to `com.android.kotlin.multiplatform.library` (tracked separately).
+android.builtInKotlin=false
+android.newDsl=false
 
 #KMM
 kotlin.apple.xcodeCompatibility.nowarn=true

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,9 @@
 [versions]
-agp = "8.12.3"
+# AGP 9.1.1 requires Gradle 9.3.1+ and supports compileSdk 37. Needed by Compose 1.12
+# (the [next] channel): its androidx artifacts demand AGP >= 9.1.0 / compileSdk 37.
+# Shared by both channels; stable (Kotlin 2.3.21) runs slightly beyond its KGP-tested
+# AGP/Gradle range but builds cleanly (verified in CI).
+agp = "9.1.1"
 androidx-activityCompose = "1.13.0"
 androidx-uiTest = "1.11.2"
 circuit = "0.33.1"
@@ -8,8 +12,7 @@ compose = "1.11.1"
 compose-material3 = "1.11.0-alpha07"
 # https://developer.android.com/develop/ui/compose/bom/bom-mapping
 composeBom = "2026.05.01"
-# androidx.core 1.19.0 requires AGP 9.1+ / compileSdk 37; capped at 1.17.0 until the AGP 9 upgrade
-coreKtx = "1.17.0"
+coreKtx = "1.19.0"
 # org.jetbrains.androidx.lifecycle KMP artifacts (desktop + android), used by docs-examples
 jetbrains-lifecycle = "2.10.0"
 # Compose Multiplatform 1.11 requires Kotlin >= 2.3.10 for native/web targets

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.3.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/library/build.gradle.kts
+++ b/library/build.gradle.kts
@@ -149,7 +149,7 @@ compose.resources {
 
 android {
     namespace = "com.chrisjenx.yakcov"
-    compileSdk = 36
+    compileSdk = 37
 
     defaultConfig {
         minSdk = 23
@@ -161,7 +161,7 @@ android {
     }
     //https://developer.android.com/studio/test/gradle-managed-devices
     testOptions {
-        targetSdk = 36
+        targetSdk = 37
         unitTests {
             isIncludeAndroidResources = true
         }

--- a/sample/build.gradle.kts
+++ b/sample/build.gradle.kts
@@ -9,12 +9,12 @@ plugins {
 
 android {
     namespace = "com.chrisjenx.yakcov.sample"
-    compileSdk = 36
+    compileSdk = 37
 
     defaultConfig {
         applicationId = "com.chrisjenx.yakcov.sample"
         minSdk = 23
-        targetSdk = 36
+        targetSdk = 37
         versionCode = 1
         versionName = "1.0"
 


### PR DESCRIPTION
## Why

The matrix run on #24 proved Compose `1.12.0-alpha01` builds on JVM/JS/iOS but **fails on Android** (`checkDebugUnitTestAarMetadata`): its androidx artifacts (`androidx.compose.*:1.12.0-alpha02`, `material3:1.5.0-alpha19`) require **AGP ≥ 9.1.0 and compileSdk 37**. This PR does that toolchain upgrade so the `[next]` channel can ride 1.12. It also unblocks `androidx.core` 1.19.0 for **stable** (the version that was capped at 1.17.0 pending exactly this).

This PR does **not** enable `[next]` — that's #24, which rebases on top once this lands.

## Changes

| | from | to |
|---|---|---|
| AGP | 8.12.3 | **9.1.1** |
| Gradle wrapper | 8.14.2 | **9.3.1** (AGP 9.1.1 min) |
| compileSdk / targetSdk | 36 | **37** (`:library`, `:sample`, `:docs-examples`) |
| androidx.core | 1.17.0 | **1.19.0** |

## AGP 9 escape hatch

AGP 9 made `com.android.library` incompatible with `kotlin-multiplatform` and defaults to built-in Kotlin + a new DSL. The KMP modules (`:library`, `:docs-examples`) still apply `com.android.library` + `androidTarget {}`, so this sets `android.builtInKotlin=false` + `android.newDsl=false` to keep the legacy path working. The proper fix — migrating to the `com.android.kotlin.multiplatform.library` plugin — is deferred to a follow-up ticket. Only non-fatal deprecation warnings remain.

## Compatibility note

AGP is a single shared version across both channels. Stable (Kotlin 2.3.21) is fully-tested only to Gradle 9.3.0 / AGP 9.0.0, so on 9.3.1 / 9.1.1 it runs a hair beyond that range — but builds cleanly. Next (Kotlin 2.4.0) supports Gradle ≤ 9.5.0 / AGP ≤ 9.1.0, so it's in range.

## Verified locally (Gradle 9.3.1 + AGP 9.1.1, stable toolchain)

- `./gradlew help` — configures all modules ✅
- `:library:testDebugUnitTest` incl. `checkDebugUnitTestAarMetadata` ✅ (the task that failed on 1.12)
- `:docs-examples:compileDebugKotlinAndroid` + `compileKotlinJvm` ✅
- configuration cache stored + reused ✅

CI validates JS / iOS / full JVM across the stable channel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)