### PR TITLE
build: bump vanniktech maven-publish 0.34.0 → 0.36.0 (Gradle 9 signing)

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -59,5 +59,5 @@ compose = { id = "org.jetbrains.compose", version.ref = "compose" }
 compose-compiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
-maven-publish = { id = "com.vanniktech.maven.publish", version = "0.34.0" }
+maven-publish = { id = "com.vanniktech.maven.publish", version = "0.36.0" }
 multiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "kotlin" }


### PR DESCRIPTION
The AGP-9 upgrade (#25) moved the repo to Gradle 9.3.1, but the publish plugin stayed at **0.34.0** (pre-Gradle-9). The real release then failed three times at `:library:signAndroidReleasePublication` with **"Could not read PGP secret key"** — the in-memory key reader choking under Gradle 9, despite:

- a verified-valid armored signing key (correct header, `secret key packet`, 108 lines),
- working Maven Central creds, and
- a byte-identical signing setup to our sibling repo **kinvoicing**, which publishes fine with the same key on vanniktech **0.36.0**.

"Could not read PGP secret key" is thrown when the plugin can't parse the key *content* (before the passphrase is applied), which points at the plugin/Gradle version, not the secret.

Bumps to **0.36.0** to match the proven kinvoicing setup. Verified locally that the full publish task graph configures under Gradle 9.3.1 + 0.36.0 (`:library:publishToMavenLocal --dry-run` builds clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)