### PR TITLE
feat: generic validation rule sweep (#31–#35), InList fix, Node-24 CI pinning (#23)

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -15,7 +15,7 @@ jobs:
       matrix: ${{ steps.parse.outputs.matrix }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Parse compose-releases.toml
         id: parse
         run: |
@@ -28,9 +28,9 @@ jobs:
     name: Checks-Scripts
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: '3.12'
       - name: Compose tracker self-test (offline)
@@ -48,11 +48,11 @@ jobs:
     name: Checks-JS (${{ matrix.channel }})
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Get tags
         run: git fetch --tags origin
       - name: Setup Java JDK
-        uses: actions/setup-java@v4.2.1
+        uses: actions/setup-java@ad2b38190b15e4d6bdf0c97fb4fca8412226d287 # v5.3.0
         with:
           distribution: 'zulu'
           java-version: '21'
@@ -60,13 +60,20 @@ jobs:
       - name: Patch Compose versions
         run: ./scripts/lib-release.sh --patch "${{ matrix.channel }}"
       - name: Setup Chrome
-        uses: browser-actions/setup-chrome@v1.7.2
+        id: setup-chrome
+        uses: browser-actions/setup-chrome@2e1d749697dd1612b833dba4a722266286fbefcd # v2.1.2
       - name: Run Js tests
+        # v2 installs "Chrome for Testing" (binary not necessarily named google-chrome),
+        # so point Karma at the exact path instead of relying on PATH name resolution.
+        env:
+          CHROME_BIN: ${{ steps.setup-chrome.outputs.chrome-path }}
         run: ./gradlew jsBrowserTest --warn --continue
       - name: Run Wasm tests
+        env:
+          CHROME_BIN: ${{ steps.setup-chrome.outputs.chrome-path }}
         run: ./gradlew wasmJsBrowserTest --warn --continue
       - name: Publish Test Report
-        uses: mikepenz/action-junit-report@v4
+        uses: mikepenz/action-junit-report@3a81627bfac62268172037048872e8ebd4207e6d # v6.4.1
         if: success() || failure()
         with:
           report_paths: '**/build/test-results/**/TEST-*.xml'
@@ -85,11 +92,11 @@ jobs:
     name: Checks-Jvm (${{ matrix.channel }})
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Get tags
         run: git fetch --tags origin
       - name: Setup Java JDK
-        uses: actions/setup-java@v4.2.1
+        uses: actions/setup-java@ad2b38190b15e4d6bdf0c97fb4fca8412226d287 # v5.3.0
         with:
           distribution: 'zulu'
           java-version: '21'
@@ -99,7 +106,7 @@ jobs:
       - name: Run Android and JVM tests
         run: ./gradlew :library:testDebugUnitTest :library:jvmTest :docs-examples:compileDebugKotlinAndroid :docs-examples:compileKotlinJvm --warn --continue
       - name: Publish Test Report
-        uses: mikepenz/action-junit-report@v4
+        uses: mikepenz/action-junit-report@3a81627bfac62268172037048872e8ebd4207e6d # v6.4.1
         if: success() || failure()
         with:
           report_paths: '**/build/test-results/**/TEST-*.xml'
@@ -118,14 +125,14 @@ jobs:
     name: Checks-Apple (${{ matrix.channel }})
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Get tags
         run: git fetch --tags origin
       - name: Select Xcode version
         if: ${{ matrix.xcode != '' }}
         run: sudo xcode-select -s /Applications/Xcode_${{ matrix.xcode }}.app
       - name: Setup Java JDK
-        uses: actions/setup-java@v4.2.1
+        uses: actions/setup-java@ad2b38190b15e4d6bdf0c97fb4fca8412226d287 # v5.3.0
         with:
           distribution: 'zulu'
           java-version: '21'
@@ -135,7 +142,7 @@ jobs:
       - name: Run Apple tests
         run: ./gradlew :library:iosSimulatorArm64Test --warn --continue
       - name: Publish Test Report
-        uses: mikepenz/action-junit-report@v4
+        uses: mikepenz/action-junit-report@3a81627bfac62268172037048872e8ebd4207e6d # v6.4.1
         if: success() || failure()
         with:
           report_paths: '**/build/test-results/**/TEST-*.xml'

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -27,9 +27,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: '3.12'
       - name: Install MkDocs Material

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
       matrix: ${{ steps.parse.outputs.matrix }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
           fetch-tags: true
@@ -53,7 +53,7 @@ jobs:
     name: Publish (${{ matrix.channel }} → ${{ matrix.tag }})
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
           fetch-tags: true
@@ -61,7 +61,7 @@ jobs:
         if: ${{ matrix.xcode != '' }}
         run: sudo xcode-select -s /Applications/Xcode_${{ matrix.xcode }}.app
       - name: Setup Java JDK
-        uses: actions/setup-java@v4.2.1
+        uses: actions/setup-java@ad2b38190b15e4d6bdf0c97fb4fca8412226d287 # v5.3.0
         with:
           distribution: 'zulu'
           java-version: '21'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -87,6 +87,21 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git tag "${{ matrix.tag }}"
           git push origin "${{ matrix.tag }}"
+      - name: Create GitHub Release
+        if: ${{ inputs.dry-run == false }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          # A pushed tag is not a Release on its own — create one so the Releases page tracks
+          # what's on Maven Central. Prerelease keys off the channel (the next/prerelease channel),
+          # NOT the tag suffix (stable's "-N" is just collision-avoidance, not a prerelease marker).
+          prerelease=""
+          if [ "${{ matrix.channel }}" != "stable" ]; then prerelease="--prerelease"; fi
+          gh release create "${{ matrix.tag }}" \
+            --title "${{ matrix.tag }}" \
+            --generate-notes \
+            --verify-tag \
+            $prerelease
 
   Summary:
     if: always()

--- a/.github/workflows/track-compose.yml
+++ b/.github/workflows/track-compose.yml
@@ -20,9 +20,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: '3.12'
       - name: Check for upstream Compose updates
@@ -31,7 +31,7 @@ jobs:
         run: |
           python3 scripts/check-compose-updates.py --write --pr-body "${RUNNER_TEMP}/pr-body.md"
       - name: Create or update pull request
-        uses: peter-evans/create-pull-request@v7
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
           branch: chore/track-compose
           base: main

--- a/docs-examples/src/commonMain/kotlin/com/chrisjenx/yakcov/docs/recipes/Recipes.kt
+++ b/docs-examples/src/commonMain/kotlin/com/chrisjenx/yakcov/docs/recipes/Recipes.kt
@@ -4,10 +4,16 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.State
 import androidx.compose.ui.Modifier
 import com.chrisjenx.yakcov.RegularValidationResult
 import com.chrisjenx.yakcov.ValidationResult
 import com.chrisjenx.yakcov.ValueValidatorRule
+import com.chrisjenx.yakcov.onlyWhen
+import com.chrisjenx.yakcov.generic.Max
+import com.chrisjenx.yakcov.generic.Min
+import com.chrisjenx.yakcov.generic.rememberGenericValueValidator
+import com.chrisjenx.yakcov.strings.MinLength
 import com.chrisjenx.yakcov.strings.Phone
 import com.chrisjenx.yakcov.strings.PhoneFormat
 import com.chrisjenx.yakcov.strings.Required
@@ -77,3 +83,25 @@ fun PhoneFormatField() {
     }
 }
 // --8<-- [end:phoneFormat]
+
+// --8<-- [start:conditional]
+// onlyWhen wraps any rule so it runs only while a State<Boolean> is true; otherwise the
+// value passes. Collapses conditionally-required / optional-when-hidden fields into the
+// existing rules instead of a bespoke rule per case.
+fun taxIdRules(isBusiness: State<Boolean>): List<ValueValidatorRule<String>> =
+    listOf(Required.onlyWhen(isBusiness), MinLength(9).onlyWhen(isBusiness))
+// --8<-- [end:conditional]
+
+// --8<-- [start:generic-bounds]
+@Composable
+fun QuantityField() {
+    // Typed numeric bounds validate the value directly (no string parsing). null and NaN
+    // pass — pair with generic Required for presence. The value type must be nullable
+    // (Int?) so the bounds' null pass-through type-checks.
+    val quantity = rememberGenericValueValidator<Int?>(
+        state = 1,
+        rules = listOf(Min(1), Max(99)),
+    )
+    Text(if (quantity.isValid) "OK" else "Enter 1–99")
+}
+// --8<-- [end:generic-bounds]

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -17,7 +17,8 @@ rule only while the flag is `true` and passes otherwise.
 --8<-- "docs-examples/src/commonMain/kotlin/com/chrisjenx/yakcov/docs/recipes/Recipes.kt:custom-rule-sam"
 ```
 
-See [custom rules](recipes/custom-rules.md) for reusable rule types and severity grading.
+See the [built-in rules](recipes/built-in-rules.md) reference for the full catalog, and
+[custom rules](recipes/custom-rules.md) for reusable rule types and severity grading.
 
 ## Two validator families
 
@@ -40,7 +41,9 @@ typing.
 - `isError()` / `FieldValidationState.isError` — true once errors are shown **and**
   severity is `ERROR`
 - `supportingText()` — a ready-made slot value for Material `TextField`s; renders the
-  most severe message, or `null` when nothing should show
+  most severe message, or `null` when nothing should show. Pass `supportingText(default =
+  "…")` to show a plain hint while the field has no message (e.g. a pristine field); the
+  same `default` works on `FieldValidationState.text()`/`supportingText()`
 - `Outcome` severities: `ERROR` > `WARNING` > `INFO` > `SUCCESS`. Warnings and info
   messages flow through the same display channel without blocking submission.
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -4,8 +4,12 @@
 
 Validation is composed from `ValueValidatorRule`s. Built-ins cover the common cases —
 `Required`, `Email`, `MinLength(n)`, `MaxLength(n)`, `Phone(region)` (see
-[phone validation](recipes/phone.md)), and more in
-`com.chrisjenx.yakcov.strings` / `com.chrisjenx.yakcov.generic`.
+[phone validation](recipes/phone.md)), `HexColor`, `OneOf(allowed)`, typed numeric
+`Min`/`Max`/`InRange`, and more in `com.chrisjenx.yakcov.strings` /
+`com.chrisjenx.yakcov.generic`.
+
+Apply any rule conditionally with `onlyWhen`: `Required.onlyWhen(isBusiness)` runs the
+rule only while the flag is `true` and passes otherwise.
 
 `ValueValidatorRule` is a `fun interface`, so one-off rules are a lambda away:
 

--- a/docs/recipes/built-in-rules.md
+++ b/docs/recipes/built-in-rules.md
@@ -5,9 +5,11 @@ implements `ValueValidatorRule<V>`; drop them into a validator's `rules` list. T
 own, see [custom rules](custom-rules.md).
 
 !!! note "Blank / null pass through"
-    The string rules treat **blank** input as valid and the generic rules treat **null** as
-    valid, so `Required` (or generic `Required`) is the single source of presence-checking.
-    `listOf(Email)` accepts an empty field; `listOf(Required, Email)` doesn't.
+    The string rules treat **blank** input as valid, and the value-membership/bounds generic
+    rules (`InList`, `Min`, `Max`, `InRange`) treat **null** as valid — so `Required` (or
+    generic `Required`) is the single source of presence-checking. `listOf(Email)` accepts an
+    empty field; `listOf(Required, Email)` doesn't. (`ListNotEmpty` and `IsChecked` are
+    themselves presence/state checks and reject null.)
 
 ## String rules
 

--- a/docs/recipes/built-in-rules.md
+++ b/docs/recipes/built-in-rules.md
@@ -1,0 +1,68 @@
+# Built-in rules
+
+Yakcov ships rules for the common cases so you rarely have to write your own. Every rule
+implements `ValueValidatorRule<V>`; drop them into a validator's `rules` list. To write your
+own, see [custom rules](custom-rules.md).
+
+!!! note "Blank / null pass through"
+    The string rules treat **blank** input as valid and the generic rules treat **null** as
+    valid, so `Required` (or generic `Required`) is the single source of presence-checking.
+    `listOf(Email)` accepts an empty field; `listOf(Required, Email)` doesn't.
+
+## String rules
+
+`com.chrisjenx.yakcov.strings` — validate the text of a `TextField`
+(`rememberTextFieldValueValidator`).
+
+| Rule | Passes when |
+|---|---|
+| `Required` | the value is not blank |
+| `Email` | the value is a valid email address |
+| `Phone(region)` | a valid phone number for an ISO region — needs libphonenumber, see [phone validation](phone.md) |
+| `PhoneFormat` | the value *looks like* a phone number — lenient, no extra dependency |
+| `Numeric` | the value parses as a whole number |
+| `Decimal` | the value parses as a decimal |
+| `MinValue(n)` / `MaxValue(n)` | the parsed numeric value is `>= n` / `<= n` |
+| `MinLength(n)` / `MaxLength(n)` | the length is within bounds (`MinLength` can `trim` and exclude whitespace) |
+| `HexColor` | a CSS hex color: `#RGB`, `#RGBA`, `#RRGGBB` or `#RRGGBBAA` (case-insensitive) |
+| `OneOf(allowed)` | the value is one of a `Set<String>` — trims and ignores case by default (`ignoreCase` / `trim` flags) |
+| `DayValidation` / `MonthValidation` / `YearValidation` | the day/month/year part forms a valid date (given a sibling `LocalDate`) |
+| `PasswordMatches(other)` | the value equals another field's value |
+
+## Generic rules
+
+`com.chrisjenx.yakcov.generic` — validate a typed value `T` directly, with
+`rememberGenericValueValidator(state, rules)`.
+
+| Rule | Passes when |
+|---|---|
+| `Required<T>()` | the value is not null |
+| `InList(allowed)` | the value is one of `allowed` (null passes) |
+| `ListNotEmpty()` | the `List` value is non-empty |
+| `IsChecked` / `IsNotChecked` | a `Boolean?` is / isn't `true` |
+| `Min(n)` / `Max(n)` / `InRange(min, max)` | a numeric `N? where N : Number, Comparable` is in range — `null` and `NaN` pass |
+
+The typed numeric bounds complement the string-based `MinValue`/`MaxValue` for fields whose
+value is already numeric. Because they pass `null` through, the validator's value type must be
+nullable (e.g. `Int?`):
+
+```kotlin
+--8<-- "docs-examples/src/commonMain/kotlin/com/chrisjenx/yakcov/docs/recipes/Recipes.kt:generic-bounds"
+```
+
+## Conditional rules
+
+`onlyWhen` (and the underlying `Optional`) wrap **any** rule — string or generic — so it runs
+only while a `State<Boolean>` is `true`, and passes otherwise. Use it for
+conditionally-required or optional-when-hidden fields instead of writing a bespoke variant:
+
+```kotlin
+--8<-- "docs-examples/src/commonMain/kotlin/com/chrisjenx/yakcov/docs/recipes/Recipes.kt:conditional"
+```
+
+## Severities
+
+Rules aren't limited to pass/fail. `ValidationResult.outcome()` is ranked
+`ERROR` > `WARNING` > `INFO` > `SUCCESS`; only `ERROR` blocks `validate()`/submission, while
+warnings and info still surface through [`supportingText`](../getting-started.md#showing-errors).
+See [custom rules](custom-rules.md#severities-and-results) for grading your own.

--- a/docs/recipes/custom-rules.md
+++ b/docs/recipes/custom-rules.md
@@ -1,7 +1,9 @@
 # Custom rules
 
 A rule is anything implementing `ValueValidatorRule<V>` — return a `ValidationResult`
-from `validate(value)`.
+from `validate(value)`. For the rules that already ship, see
+[built-in rules](built-in-rules.md); to run an existing rule only sometimes, see
+[`onlyWhen`](built-in-rules.md#conditional-rules).
 
 ## Reusable rule types
 

--- a/library/karma.config.d/chrome-headless-ci.js
+++ b/library/karma.config.d/chrome-headless-ci.js
@@ -1,0 +1,12 @@
+// Chrome for Testing (installed by browser-actions/setup-chrome v2) refuses to start under the
+// default ChromeHeadless launcher inside CI sandboxes ("Cannot start ChromeHeadless"). Add the
+// standard CI-safe flags. Harmless locally. Applies to both the js and wasmJs browser tests.
+config.set({
+    customLaunchers: {
+        ChromeHeadlessNoSandbox: {
+            base: 'ChromeHeadless',
+            flags: ['--no-sandbox', '--disable-dev-shm-usage', '--disable-gpu'],
+        },
+    },
+    browsers: ['ChromeHeadlessNoSandbox'],
+});

--- a/library/src/commonMain/composeResources/values/strings.xml
+++ b/library/src/commonMain/composeResources/values/strings.xml
@@ -20,4 +20,5 @@
     <string name="ruleYear">Invalid year</string>
     <string name="ruleInvalidDate">Invalid date %1$s</string>
     <string name="rulePasswords">Passwords do not match</string>
+    <string name="ruleHexColor">Invalid hex color</string>
 </resources>

--- a/library/src/commonMain/kotlin/com/chrisjenx/yakcov/FieldValidationState.kt
+++ b/library/src/commonMain/kotlin/com/chrisjenx/yakcov/FieldValidationState.kt
@@ -89,14 +89,15 @@ fun <V> List<ValueValidatorRule<V>>.toFieldState(value: V, showError: Boolean): 
 fun List<FieldValidationState>.hasNoErrors(): Boolean = none { it.severity == Outcome.ERROR }
 
 /**
- * Resolve the field's message for display, or `null` when there is nothing to show. Gated on
- * [showError]: returns `null` until errors are shown (focus loss/submit), so the message tracks the
- * same showError gating as [isError]/[isWarning] — no message pops while the user is still typing.
- * [Composable] because resource-backed results resolve their `StringResource` here. For the raw,
- * ungated message (regardless of showError) use `result?.format()` directly.
+ * Resolve the field's message for display, falling back to [default] (or `null`) when there is no
+ * message to show. Only the *validation message* is gated on [showError]: it stays hidden until
+ * errors are shown (focus loss/submit) — the same gating as [isError]/[isWarning], so no message
+ * pops while the user is still typing — whereas [default] is shown whenever no message is displayed,
+ * including on a pristine (`showError == false`) field. [Composable] because resource-backed results
+ * resolve their `StringResource` here. For the raw, ungated message use `result?.format()` directly.
  *
- * @param default a plain hint shown when there is no message to display (e.g. a pristine field).
- *  Defaults to `null`, preserving the prior return-`null`-when-nothing-to-show behavior.
+ * @param default a plain hint shown when there is no validation message to display (e.g. a pristine
+ *  field). Defaults to `null`, preserving the prior return-`null`-when-nothing-to-show behavior.
  */
 @Composable
 fun FieldValidationState.text(default: String? = null): String? =

--- a/library/src/commonMain/kotlin/com/chrisjenx/yakcov/FieldValidationState.kt
+++ b/library/src/commonMain/kotlin/com/chrisjenx/yakcov/FieldValidationState.kt
@@ -94,17 +94,23 @@ fun List<FieldValidationState>.hasNoErrors(): Boolean = none { it.severity == Ou
  * same showError gating as [isError]/[isWarning] — no message pops while the user is still typing.
  * [Composable] because resource-backed results resolve their `StringResource` here. For the raw,
  * ungated message (regardless of showError) use `result?.format()` directly.
+ *
+ * @param default a plain hint shown when there is no message to display (e.g. a pristine field).
+ *  Defaults to `null`, preserving the prior return-`null`-when-nothing-to-show behavior.
  */
 @Composable
-fun FieldValidationState.text(): String? = if (showError) result?.format() else null
+fun FieldValidationState.text(default: String? = null): String? =
+    (if (showError) result?.format() else null) ?: default
 
 /**
  * Convenience that mirrors `ValueValidator.supportingText()`: returns a composable that renders the
- * shown message (see [text]), or `null` when there is none / errors aren't shown yet. Drops
+ * shown message (see [text]) or the [default] hint, or `null` when there is neither. Drops
  * the `text()?.let { Text(it) }` boilerplate.
+ *
+ * @param default a plain hint shown when there is no validation message (see [text]).
  */
 @Composable
-fun FieldValidationState.supportingText(): (@Composable () -> Unit)? {
-    val message = text() ?: return null
+fun FieldValidationState.supportingText(default: String? = null): (@Composable () -> Unit)? {
+    val message = text(default) ?: return null
     return { Text(message) }
 }

--- a/library/src/commonMain/kotlin/com/chrisjenx/yakcov/RuleCombinators.kt
+++ b/library/src/commonMain/kotlin/com/chrisjenx/yakcov/RuleCombinators.kt
@@ -1,0 +1,39 @@
+package com.chrisjenx.yakcov
+
+import androidx.compose.runtime.Stable
+import androidx.compose.runtime.State
+import androidx.compose.runtime.getValue
+
+/**
+ * Runs [rule] only while [enabled] is `true`; otherwise the value is treated as valid
+ * ([RegularValidationResult.success]). Collapses the "apply rule R only when some flag holds"
+ * pattern (conditionally-required fields, optional-when-hidden inputs) into one combinator instead
+ * of a bespoke rule per case.
+ *
+ * Prefer the [onlyWhen] extension for readability: `Required.onlyWhen(isBusiness)`.
+ */
+@Stable
+class Optional<V>(
+    private val enabled: State<Boolean>,
+    private val rule: ValueValidatorRule<V>,
+) : ValueValidatorRule<V> {
+    constructor(enabled: Boolean, rule: ValueValidatorRule<V>) :
+        this(ImmutableBooleanState(enabled), rule)
+
+    private val _enabled by enabled
+
+    override fun validate(value: V): ValidationResult =
+        if (_enabled) rule.validate(value) else RegularValidationResult.success()
+}
+
+/**
+ * Applies this rule only while [enabled] is `true`. See [Optional].
+ */
+fun <V> ValueValidatorRule<V>.onlyWhen(enabled: State<Boolean>): ValueValidatorRule<V> =
+    Optional(enabled, this)
+
+/**
+ * Applies this rule only when [enabled] is `true`. See [Optional].
+ */
+fun <V> ValueValidatorRule<V>.onlyWhen(enabled: Boolean): ValueValidatorRule<V> =
+    Optional(enabled, this)

--- a/library/src/commonMain/kotlin/com/chrisjenx/yakcov/RuleCombinators.kt
+++ b/library/src/commonMain/kotlin/com/chrisjenx/yakcov/RuleCombinators.kt
@@ -33,7 +33,8 @@ fun <V> ValueValidatorRule<V>.onlyWhen(enabled: State<Boolean>): ValueValidatorR
     Optional(enabled, this)
 
 /**
- * Applies this rule only when [enabled] is `true`. See [Optional].
+ * Applies this rule only when [enabled] is `true`. [enabled] is captured once; for a flag that
+ * changes at runtime pass the [State] overload so the rule re-evaluates. See [Optional].
  */
 fun <V> ValueValidatorRule<V>.onlyWhen(enabled: Boolean): ValueValidatorRule<V> =
     Optional(enabled, this)

--- a/library/src/commonMain/kotlin/com/chrisjenx/yakcov/States.kt
+++ b/library/src/commonMain/kotlin/com/chrisjenx/yakcov/States.kt
@@ -21,3 +21,6 @@ internal class ImmutableLocalDateState(override val value: LocalDate) : State<Lo
 
 @Immutable
 internal class ImmutableListState<T>(override val value: List<T>) : State<List<T>>
+
+@Immutable
+internal class ImmutableValueState<T>(override val value: T) : State<T>

--- a/library/src/commonMain/kotlin/com/chrisjenx/yakcov/ValueValidator.kt
+++ b/library/src/commonMain/kotlin/com/chrisjenx/yakcov/ValueValidator.kt
@@ -164,14 +164,19 @@ abstract class ValueValidator<V, R>(
      * Generates a supporting error text for your TextField.
      *
      * @param severity the minimum severity to show, defaults to [Outcome.SUCCESS.severity]
+     * @param default a plain hint shown when there is no validation message to display (e.g. a
+     *  pristine field that isn't validating yet). Defaults to `null`, preserving the prior
+     *  return-`null`-when-nothing-to-show behavior.
      */
     @Composable
-    fun supportingText(severity: Short = Outcome.SUCCESS.severity): (@Composable () -> Unit)? {
+    fun supportingText(
+        severity: Short = Outcome.SUCCESS.severity,
+        default: String? = null,
+    ): (@Composable () -> Unit)? {
         val isValidating = internalState is InternalState.Validating
-        if (alwaysShowRule || isValidating) getValidationResultString(severity)?.let { validations ->
-            return { Text(validations) }
-        }
-        return null
+        val message = if (alwaysShowRule || isValidating) getValidationResultString(severity) else null
+        val text = message ?: default ?: return null
+        return { Text(text) }
     }
 
     /**

--- a/library/src/commonMain/kotlin/com/chrisjenx/yakcov/ValueValidator.kt
+++ b/library/src/commonMain/kotlin/com/chrisjenx/yakcov/ValueValidator.kt
@@ -161,7 +161,9 @@ abstract class ValueValidator<V, R>(
     }
 
     /**
-     * Generates a supporting error text for your TextField.
+     * Builds the supporting-text slot for your TextField: the most-severe validation message when
+     * one should show, otherwise the [default] hint (or `null`). Not limited to errors — warning,
+     * info, and the [default] hint all render through this same slot.
      *
      * @param severity the minimum severity to show, defaults to [Outcome.SUCCESS.severity]
      * @param default a plain hint shown when there is no validation message to display (e.g. a

--- a/library/src/commonMain/kotlin/com/chrisjenx/yakcov/generic/GenericValueValidatorRules.kt
+++ b/library/src/commonMain/kotlin/com/chrisjenx/yakcov/generic/GenericValueValidatorRules.kt
@@ -32,8 +32,9 @@ class InList<T>(list: State<List<T>>) : ValueValidatorRule<T?> {
 
     private val list: List<T> by list
     override fun validate(value: T?): ValidationResult {
-        return if (value in list) ResourceValidationResult.error(Res.string.ruleInList)
-        else RegularValidationResult.success()
+        // value must be one of the allowed values; null passes (Required owns presence)
+        return if (value == null || value in list) RegularValidationResult.success()
+        else ResourceValidationResult.error(Res.string.ruleInList)
     }
 }
 

--- a/library/src/commonMain/kotlin/com/chrisjenx/yakcov/generic/GenericValueValidatorRules.kt
+++ b/library/src/commonMain/kotlin/com/chrisjenx/yakcov/generic/GenericValueValidatorRules.kt
@@ -62,6 +62,10 @@ data object IsNotChecked : ValueValidatorRule<Boolean?> {
     }
 }
 
+// NaN is not meaningfully comparable, so the numeric bounds let it pass like null — presence and
+// validity of the raw value are owned by [Required]. Integral types never report NaN.
+private fun Number.isNotANumber(): Boolean = toDouble().isNaN()
+
 /**
  * Typed lower bound for a numeric field, complementing the String-based
  * [com.chrisjenx.yakcov.strings.MinValue]. `null` and `NaN` pass through (use [Required] for
@@ -73,11 +77,9 @@ class Min<N>(min: State<N>) : ValueValidatorRule<N?> where N : Number, N : Compa
 
     private val _min: N by min
     override fun validate(value: N?): ValidationResult {
-        return when {
-            value == null || value.toDouble().isNaN() -> RegularValidationResult.success()
-            value < _min -> ResourceValidationResult.error(Res.string.ruleMinValue, _min)
-            else -> RegularValidationResult.success()
-        }
+        if (value == null || value.isNotANumber()) return RegularValidationResult.success()
+        return if (value >= _min) RegularValidationResult.success()
+        else ResourceValidationResult.error(Res.string.ruleMinValue, _min)
     }
 }
 
@@ -92,31 +94,26 @@ class Max<N>(max: State<N>) : ValueValidatorRule<N?> where N : Number, N : Compa
 
     private val _max: N by max
     override fun validate(value: N?): ValidationResult {
-        return when {
-            value == null || value.toDouble().isNaN() -> RegularValidationResult.success()
-            value > _max -> ResourceValidationResult.error(Res.string.ruleMaxValue, _max)
-            else -> RegularValidationResult.success()
-        }
+        if (value == null || value.isNotANumber()) return RegularValidationResult.success()
+        return if (value <= _max) RegularValidationResult.success()
+        else ResourceValidationResult.error(Res.string.ruleMaxValue, _max)
     }
 }
 
 /**
  * Typed inclusive range `[min, max]` for a numeric field. `null` and `NaN` pass through; below
- * [min] reports the min message, above [max] the max message.
+ * [min] reports the min message, above [max] the max message. Composed from [Min] and [Max] so
+ * the bound semantics live in one place.
  */
 @Stable
 class InRange<N>(min: State<N>, max: State<N>) : ValueValidatorRule<N?> where N : Number, N : Comparable<N> {
     constructor(min: N, max: N) : this(ImmutableValueState(min), ImmutableValueState(max))
 
-    private val _min: N by min
-    private val _max: N by max
+    private val minRule = Min(min)
+    private val maxRule = Max(max)
     override fun validate(value: N?): ValidationResult {
-        return when {
-            value == null || value.toDouble().isNaN() -> RegularValidationResult.success()
-            value < _min -> ResourceValidationResult.error(Res.string.ruleMinValue, _min)
-            value > _max -> ResourceValidationResult.error(Res.string.ruleMaxValue, _max)
-            else -> RegularValidationResult.success()
-        }
+        val low = minRule.validate(value)
+        return if (low.outcome() == ValidationResult.Outcome.ERROR) low else maxRule.validate(value)
     }
 }
 

--- a/library/src/commonMain/kotlin/com/chrisjenx/yakcov/generic/GenericValueValidatorRules.kt
+++ b/library/src/commonMain/kotlin/com/chrisjenx/yakcov/generic/GenericValueValidatorRules.kt
@@ -63,8 +63,9 @@ data object IsNotChecked : ValueValidatorRule<Boolean?> {
 }
 
 /**
- * Typed lower bound for a numeric field, complementing the String-based [strings.MinValue].
- * `null` passes through (use [Required] for presence), otherwise the value must be `>= min`.
+ * Typed lower bound for a numeric field, complementing the String-based
+ * [com.chrisjenx.yakcov.strings.MinValue]. `null` and `NaN` pass through (use [Required] for
+ * presence), otherwise the value must be `>= min`.
  */
 @Stable
 class Min<N>(min: State<N>) : ValueValidatorRule<N?> where N : Number, N : Comparable<N> {
@@ -73,7 +74,7 @@ class Min<N>(min: State<N>) : ValueValidatorRule<N?> where N : Number, N : Compa
     private val _min: N by min
     override fun validate(value: N?): ValidationResult {
         return when {
-            value == null -> RegularValidationResult.success()
+            value == null || value.toDouble().isNaN() -> RegularValidationResult.success()
             value < _min -> ResourceValidationResult.error(Res.string.ruleMinValue, _min)
             else -> RegularValidationResult.success()
         }
@@ -81,8 +82,9 @@ class Min<N>(min: State<N>) : ValueValidatorRule<N?> where N : Number, N : Compa
 }
 
 /**
- * Typed upper bound for a numeric field, complementing the String-based [strings.MaxValue].
- * `null` passes through (use [Required] for presence), otherwise the value must be `<= max`.
+ * Typed upper bound for a numeric field, complementing the String-based
+ * [com.chrisjenx.yakcov.strings.MaxValue]. `null` and `NaN` pass through (use [Required] for
+ * presence), otherwise the value must be `<= max`.
  */
 @Stable
 class Max<N>(max: State<N>) : ValueValidatorRule<N?> where N : Number, N : Comparable<N> {
@@ -91,7 +93,7 @@ class Max<N>(max: State<N>) : ValueValidatorRule<N?> where N : Number, N : Compa
     private val _max: N by max
     override fun validate(value: N?): ValidationResult {
         return when {
-            value == null -> RegularValidationResult.success()
+            value == null || value.toDouble().isNaN() -> RegularValidationResult.success()
             value > _max -> ResourceValidationResult.error(Res.string.ruleMaxValue, _max)
             else -> RegularValidationResult.success()
         }
@@ -99,8 +101,8 @@ class Max<N>(max: State<N>) : ValueValidatorRule<N?> where N : Number, N : Compa
 }
 
 /**
- * Typed inclusive range `[min, max]` for a numeric field. `null` passes through; below [min]
- * reports the min message, above [max] the max message.
+ * Typed inclusive range `[min, max]` for a numeric field. `null` and `NaN` pass through; below
+ * [min] reports the min message, above [max] the max message.
  */
 @Stable
 class InRange<N>(min: State<N>, max: State<N>) : ValueValidatorRule<N?> where N : Number, N : Comparable<N> {
@@ -110,7 +112,7 @@ class InRange<N>(min: State<N>, max: State<N>) : ValueValidatorRule<N?> where N 
     private val _max: N by max
     override fun validate(value: N?): ValidationResult {
         return when {
-            value == null -> RegularValidationResult.success()
+            value == null || value.toDouble().isNaN() -> RegularValidationResult.success()
             value < _min -> ResourceValidationResult.error(Res.string.ruleMinValue, _min)
             value > _max -> ResourceValidationResult.error(Res.string.ruleMaxValue, _max)
             else -> RegularValidationResult.success()

--- a/library/src/commonMain/kotlin/com/chrisjenx/yakcov/generic/GenericValueValidatorRules.kt
+++ b/library/src/commonMain/kotlin/com/chrisjenx/yakcov/generic/GenericValueValidatorRules.kt
@@ -4,6 +4,7 @@ import androidx.compose.runtime.Stable
 import androidx.compose.runtime.State
 import androidx.compose.runtime.getValue
 import com.chrisjenx.yakcov.ImmutableListState
+import com.chrisjenx.yakcov.ImmutableValueState
 import com.chrisjenx.yakcov.RegularValidationResult
 import com.chrisjenx.yakcov.ResourceValidationResult
 import com.chrisjenx.yakcov.ValidationResult
@@ -12,6 +13,8 @@ import yakcov.library.generated.resources.Res
 import yakcov.library.generated.resources.ruleInList
 import yakcov.library.generated.resources.ruleIsChecked
 import yakcov.library.generated.resources.ruleIsNotChecked
+import yakcov.library.generated.resources.ruleMaxValue
+import yakcov.library.generated.resources.ruleMinValue
 import yakcov.library.generated.resources.ruleNotEmptyList
 import yakcov.library.generated.resources.ruleNotNull
 
@@ -55,6 +58,62 @@ data object IsNotChecked : ValueValidatorRule<Boolean?> {
     override fun validate(value: Boolean?): ValidationResult {
         return if (value != true) RegularValidationResult.success()
         else ResourceValidationResult.error(Res.string.ruleIsNotChecked)
+    }
+}
+
+/**
+ * Typed lower bound for a numeric field, complementing the String-based [strings.MinValue].
+ * `null` passes through (use [Required] for presence), otherwise the value must be `>= min`.
+ */
+@Stable
+class Min<N>(min: State<N>) : ValueValidatorRule<N?> where N : Number, N : Comparable<N> {
+    constructor(min: N) : this(ImmutableValueState(min))
+
+    private val _min: N by min
+    override fun validate(value: N?): ValidationResult {
+        return when {
+            value == null -> RegularValidationResult.success()
+            value < _min -> ResourceValidationResult.error(Res.string.ruleMinValue, _min)
+            else -> RegularValidationResult.success()
+        }
+    }
+}
+
+/**
+ * Typed upper bound for a numeric field, complementing the String-based [strings.MaxValue].
+ * `null` passes through (use [Required] for presence), otherwise the value must be `<= max`.
+ */
+@Stable
+class Max<N>(max: State<N>) : ValueValidatorRule<N?> where N : Number, N : Comparable<N> {
+    constructor(max: N) : this(ImmutableValueState(max))
+
+    private val _max: N by max
+    override fun validate(value: N?): ValidationResult {
+        return when {
+            value == null -> RegularValidationResult.success()
+            value > _max -> ResourceValidationResult.error(Res.string.ruleMaxValue, _max)
+            else -> RegularValidationResult.success()
+        }
+    }
+}
+
+/**
+ * Typed inclusive range `[min, max]` for a numeric field. `null` passes through; below [min]
+ * reports the min message, above [max] the max message.
+ */
+@Stable
+class InRange<N>(min: State<N>, max: State<N>) : ValueValidatorRule<N?> where N : Number, N : Comparable<N> {
+    constructor(min: N, max: N) : this(ImmutableValueState(min), ImmutableValueState(max))
+
+    private val _min: N by min
+    private val _max: N by max
+    override fun validate(value: N?): ValidationResult {
+        return when {
+            value == null -> RegularValidationResult.success()
+            value < _min -> ResourceValidationResult.error(Res.string.ruleMinValue, _min)
+            value > _max -> ResourceValidationResult.error(Res.string.ruleMaxValue, _max)
+            else -> RegularValidationResult.success()
+        }
     }
 }
 

--- a/library/src/commonMain/kotlin/com/chrisjenx/yakcov/strings/StringValueValidatorRules.kt
+++ b/library/src/commonMain/kotlin/com/chrisjenx/yakcov/strings/StringValueValidatorRules.kt
@@ -11,6 +11,7 @@ import com.chrisjenx.yakcov.ImmutableIntState
 import com.chrisjenx.yakcov.ImmutableLocalDateState
 import com.chrisjenx.yakcov.ImmutableNumberState
 import com.chrisjenx.yakcov.ImmutableStringState
+import com.chrisjenx.yakcov.ImmutableValueState
 import com.chrisjenx.yakcov.ResourceValidationResult
 import com.chrisjenx.yakcov.ValidationResult
 import com.chrisjenx.yakcov.ValueValidator
@@ -24,6 +25,7 @@ import yakcov.library.generated.resources.ruleDay
 import yakcov.library.generated.resources.ruleDecimal
 import yakcov.library.generated.resources.ruleEmail
 import yakcov.library.generated.resources.ruleHexColor
+import yakcov.library.generated.resources.ruleInList
 import yakcov.library.generated.resources.ruleInvalidDate
 import yakcov.library.generated.resources.ruleMaxLength
 import yakcov.library.generated.resources.ruleMaxValue
@@ -190,6 +192,38 @@ data object HexColor : ValueValidatorRule<String> {
             ResourceValidationResult.success()
         } else {
             ResourceValidationResult.error(Res.string.ruleHexColor)
+        }
+    }
+}
+
+// OneOf
+/**
+ * Validates that the value is one of [allowed]. By default the comparison ignores case ([ignoreCase])
+ * and [trim]s the value and each allowed entry — covering enum-ish string fields, ISO country codes,
+ * etc. Blank passes ([Required] owns emptiness).
+ */
+@Stable
+data class OneOf(
+    val allowed: State<Set<String>>,
+    val ignoreCase: Boolean = true,
+    val trim: Boolean = true,
+) : ValueValidatorRule<String> {
+    constructor(allowed: Set<String>, ignoreCase: Boolean = true, trim: Boolean = true) :
+        this(ImmutableValueState(allowed), ignoreCase, trim)
+
+    private val _allowed by allowed
+    override fun validate(value: String): ValidationResult {
+        // only validate if not empty as Required will check if not empty
+        if (value.isBlank()) return ResourceValidationResult.success()
+        val candidate = if (trim) value.trim() else value
+        val match = _allowed.any { entry ->
+            val allowedEntry = if (trim) entry.trim() else entry
+            allowedEntry.equals(candidate, ignoreCase = ignoreCase)
+        }
+        return if (match) {
+            ResourceValidationResult.success()
+        } else {
+            ResourceValidationResult.error(Res.string.ruleInList)
         }
     }
 }

--- a/library/src/commonMain/kotlin/com/chrisjenx/yakcov/strings/StringValueValidatorRules.kt
+++ b/library/src/commonMain/kotlin/com/chrisjenx/yakcov/strings/StringValueValidatorRules.kt
@@ -23,6 +23,7 @@ import yakcov.library.generated.resources.Res
 import yakcov.library.generated.resources.ruleDay
 import yakcov.library.generated.resources.ruleDecimal
 import yakcov.library.generated.resources.ruleEmail
+import yakcov.library.generated.resources.ruleHexColor
 import yakcov.library.generated.resources.ruleInvalidDate
 import yakcov.library.generated.resources.ruleMaxLength
 import yakcov.library.generated.resources.ruleMaxValue
@@ -169,6 +170,26 @@ data object Email : ValueValidatorRule<String> {
             ResourceValidationResult.error(Res.string.ruleEmail)
         } else {
             ResourceValidationResult.success()
+        }
+    }
+}
+
+// HexColor
+/**
+ * Validates a CSS-style hex color: a leading `#` followed by 3, 4, 6 or 8 hex digits
+ * (`#RGB`, `#RGBA`, `#RRGGBB`, `#RRGGBBAA`). Case-insensitive. Blank passes ([Required] owns
+ * emptiness).
+ */
+@Stable
+data object HexColor : ValueValidatorRule<String> {
+    private val regex = Regex("^#([0-9a-fA-F]{3,4}|[0-9a-fA-F]{6}|[0-9a-fA-F]{8})$")
+    override fun validate(value: String): ValidationResult {
+        // only validate if not empty as Required will check if not empty
+        if (value.isBlank()) return ResourceValidationResult.success()
+        return if (regex.matches(value)) {
+            ResourceValidationResult.success()
+        } else {
+            ResourceValidationResult.error(Res.string.ruleHexColor)
         }
     }
 }

--- a/library/src/commonTest/kotlin/com/chrisjenx/yakcov/RuleCombinatorsTest.kt
+++ b/library/src/commonTest/kotlin/com/chrisjenx/yakcov/RuleCombinatorsTest.kt
@@ -1,0 +1,56 @@
+package com.chrisjenx.yakcov
+
+import androidx.compose.runtime.mutableStateOf
+import com.chrisjenx.yakcov.ValidationResult.Outcome
+import com.chrisjenx.yakcov.strings.MinLength
+import com.chrisjenx.yakcov.strings.Required
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class RuleCombinatorsTest {
+
+    @Test
+    fun optional_enabled_delegates_to_rule_error() {
+        // Required fails on blank; when enabled the wrapped failure passes through.
+        assertEquals(Outcome.ERROR, Optional(enabled = true, rule = Required).validate("").outcome())
+    }
+
+    @Test
+    fun optional_enabled_delegates_to_rule_success() {
+        assertEquals(Outcome.SUCCESS, Optional(enabled = true, rule = Required).validate("hi").outcome())
+    }
+
+    @Test
+    fun optional_disabled_always_success() {
+        // Required would fail on blank, but the gate is off so the rule is skipped.
+        assertEquals(Outcome.SUCCESS, Optional(enabled = false, rule = Required).validate("").outcome())
+    }
+
+    @Test
+    fun optional_reacts_to_state() {
+        val enabled = mutableStateOf(false)
+        val rule = Optional(enabled = enabled, rule = Required)
+        assertEquals(Outcome.SUCCESS, rule.validate("").outcome())
+        enabled.value = true
+        assertEquals(Outcome.ERROR, rule.validate("").outcome())
+    }
+
+    @Test
+    fun onlyWhen_boolean_true_delegates() {
+        assertEquals(Outcome.ERROR, Required.onlyWhen(true).validate("").outcome())
+    }
+
+    @Test
+    fun onlyWhen_boolean_false_skips() {
+        assertEquals(Outcome.SUCCESS, Required.onlyWhen(false).validate("").outcome())
+    }
+
+    @Test
+    fun onlyWhen_state_gates_wrapped_rule() {
+        val enabled = mutableStateOf(true)
+        // MinLength(8) fails on a short non-blank value when the gate is open.
+        assertEquals(Outcome.ERROR, MinLength(8).onlyWhen(enabled).validate("abc").outcome())
+        enabled.value = false
+        assertEquals(Outcome.SUCCESS, MinLength(8).onlyWhen(enabled).validate("abc").outcome())
+    }
+}

--- a/library/src/commonTest/kotlin/com/chrisjenx/yakcov/SupportingTextDefaultTest.kt
+++ b/library/src/commonTest/kotlin/com/chrisjenx/yakcov/SupportingTextDefaultTest.kt
@@ -2,6 +2,8 @@ package com.chrisjenx.yakcov
 
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.runComposeUiTest
 import com.chrisjenx.yakcov.ValidationResult.Outcome
 import kotlin.test.Test
@@ -53,6 +55,32 @@ class SupportingTextDefaultTest {
             assertNotNull(FieldValidationState.Pristine.supportingText(default = "hint"))
             assertNull(FieldValidationState.Pristine.supportingText())
         }
+    }
+
+    @Test
+    @AndroidJUnitIgnore
+    @JSIgnore
+    fun fieldState_supportingText_rendersDefaultHint() = runComposeUiTest {
+        setContent {
+            FieldValidationState.Pristine.supportingText(default = "hint")?.invoke()
+        }
+        onNodeWithText("hint").assertIsDisplayed()
+    }
+
+    @Test
+    @AndroidJUnitIgnore
+    @JSIgnore
+    fun fieldState_supportingText_rendersMessageNotDefault() = runComposeUiTest {
+        val withMsg = FieldValidationState(
+            severity = Outcome.ERROR, showError = true,
+            result = RegularValidationResult.error("Bad value"),
+        )
+        setContent {
+            withMsg.supportingText(default = "hint")?.invoke()
+        }
+        // message wins over the default (string-level precedence is pinned by
+        // fieldState_text_prefersMessageOverDefault)
+        onNodeWithText("Bad value").assertIsDisplayed()
     }
 
     @Test

--- a/library/src/commonTest/kotlin/com/chrisjenx/yakcov/SupportingTextDefaultTest.kt
+++ b/library/src/commonTest/kotlin/com/chrisjenx/yakcov/SupportingTextDefaultTest.kt
@@ -1,0 +1,72 @@
+package com.chrisjenx.yakcov
+
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.runComposeUiTest
+import com.chrisjenx.yakcov.ValidationResult.Outcome
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+
+@OptIn(ExperimentalTestApi::class)
+class SupportingTextDefaultTest {
+
+    @Test
+    @AndroidJUnitIgnore
+    @JSIgnore
+    fun fieldState_text_fallsBackToDefault_whenNoMessage() = runComposeUiTest {
+        setContent {
+            // Pristine field has no message, so the default hint shows.
+            assertEquals("hint", FieldValidationState.Pristine.text(default = "hint"))
+        }
+    }
+
+    @Test
+    @AndroidJUnitIgnore
+    @JSIgnore
+    fun fieldState_text_prefersMessageOverDefault() = runComposeUiTest {
+        val withMsg = FieldValidationState(
+            severity = Outcome.ERROR, showError = true,
+            result = RegularValidationResult.error("Bad value"),
+        )
+        setContent {
+            assertEquals("Bad value", withMsg.text(default = "hint"))
+        }
+    }
+
+    @Test
+    @AndroidJUnitIgnore
+    @JSIgnore
+    fun fieldState_text_noDefault_isNullWhenNoMessage() = runComposeUiTest {
+        // backward compatible: no default => null
+        setContent {
+            assertNull(FieldValidationState.Pristine.text())
+        }
+    }
+
+    @Test
+    @AndroidJUnitIgnore
+    @JSIgnore
+    fun fieldState_supportingText_fallsBackToDefault() = runComposeUiTest {
+        setContent {
+            assertNotNull(FieldValidationState.Pristine.supportingText(default = "hint"))
+            assertNull(FieldValidationState.Pristine.supportingText())
+        }
+    }
+
+    @Test
+    @AndroidJUnitIgnore
+    @JSIgnore
+    fun validator_supportingText_fallsBackToDefault_whenNoMessage() = runComposeUiTest {
+        val validator = object : ValueValidator<String, String>(
+            state = mutableStateOf(""),
+            rules = emptyList(),
+            validateMapper = { validate(it) }
+        ) {}
+        setContent {
+            assertNull(validator.supportingText())
+            assertNotNull(validator.supportingText(default = "hint"))
+        }
+    }
+}

--- a/library/src/commonTest/kotlin/com/chrisjenx/yakcov/generic/InListRuleTest.kt
+++ b/library/src/commonTest/kotlin/com/chrisjenx/yakcov/generic/InListRuleTest.kt
@@ -1,0 +1,37 @@
+package com.chrisjenx.yakcov.generic
+
+import androidx.compose.runtime.mutableStateOf
+import com.chrisjenx.yakcov.ValidationResult.Outcome
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * InList means "the value must be one of the allowed list". Value present in the list -> valid.
+ */
+class InListRuleTest {
+
+    @Test
+    fun inList_value_in_list_success() {
+        assertEquals(Outcome.SUCCESS, InList(listOf("a", "b")).validate("a").outcome())
+    }
+
+    @Test
+    fun inList_value_not_in_list_error() {
+        assertEquals(Outcome.ERROR, InList(listOf("a", "b")).validate("c").outcome())
+    }
+
+    @Test
+    fun inList_null_success() {
+        // optional by default; Required owns presence
+        assertEquals(Outcome.SUCCESS, InList(listOf("a", "b")).validate(null).outcome())
+    }
+
+    @Test
+    fun inList_reacts_to_state() {
+        val allowed = mutableStateOf(listOf("a"))
+        val rule = InList(allowed)
+        assertEquals(Outcome.ERROR, rule.validate("b").outcome())
+        allowed.value = listOf("a", "b")
+        assertEquals(Outcome.SUCCESS, rule.validate("b").outcome())
+    }
+}

--- a/library/src/commonTest/kotlin/com/chrisjenx/yakcov/generic/InListRuleTest.kt
+++ b/library/src/commonTest/kotlin/com/chrisjenx/yakcov/generic/InListRuleTest.kt
@@ -27,6 +27,12 @@ class InListRuleTest {
     }
 
     @Test
+    fun inList_empty_list_value_error_but_null_success() {
+        assertEquals(Outcome.ERROR, InList(emptyList<String>()).validate("a").outcome())
+        assertEquals(Outcome.SUCCESS, InList(emptyList<String>()).validate(null).outcome())
+    }
+
+    @Test
     fun inList_reacts_to_state() {
         val allowed = mutableStateOf(listOf("a"))
         val rule = InList(allowed)

--- a/library/src/commonTest/kotlin/com/chrisjenx/yakcov/generic/NumericBoundRuleTest.kt
+++ b/library/src/commonTest/kotlin/com/chrisjenx/yakcov/generic/NumericBoundRuleTest.kt
@@ -1,0 +1,86 @@
+package com.chrisjenx.yakcov.generic
+
+import androidx.compose.runtime.mutableStateOf
+import com.chrisjenx.yakcov.ValidationResult.Outcome
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class NumericBoundRuleTest {
+
+    // --- Min ---
+
+    @Test
+    fun min_null_success() {
+        assertEquals(Outcome.SUCCESS, Min(5).validate(null).outcome())
+    }
+
+    @Test
+    fun min_at_bound_success() {
+        assertEquals(Outcome.SUCCESS, Min(5).validate(5).outcome())
+    }
+
+    @Test
+    fun min_above_bound_success() {
+        assertEquals(Outcome.SUCCESS, Min(5).validate(6).outcome())
+    }
+
+    @Test
+    fun min_below_bound_error() {
+        assertEquals(Outcome.ERROR, Min(5).validate(4).outcome())
+    }
+
+    @Test
+    fun min_reacts_to_state() {
+        val bound = mutableStateOf(5)
+        val rule = Min(bound)
+        assertEquals(Outcome.ERROR, rule.validate(4).outcome())
+        bound.value = 3
+        assertEquals(Outcome.SUCCESS, rule.validate(4).outcome())
+    }
+
+    @Test
+    fun min_supports_long_and_double() {
+        assertEquals(Outcome.ERROR, Min(5L).validate(4L).outcome())
+        assertEquals(Outcome.ERROR, Min(2.5).validate(2.0).outcome())
+        assertEquals(Outcome.SUCCESS, Min(2.5).validate(2.5).outcome())
+    }
+
+    // --- Max ---
+
+    @Test
+    fun max_null_success() {
+        assertEquals(Outcome.SUCCESS, Max(10).validate(null).outcome())
+    }
+
+    @Test
+    fun max_at_bound_success() {
+        assertEquals(Outcome.SUCCESS, Max(10).validate(10).outcome())
+    }
+
+    @Test
+    fun max_above_bound_error() {
+        assertEquals(Outcome.ERROR, Max(10).validate(11).outcome())
+    }
+
+    // --- InRange ---
+
+    @Test
+    fun inRange_null_success() {
+        assertEquals(Outcome.SUCCESS, InRange(1, 10).validate(null).outcome())
+    }
+
+    @Test
+    fun inRange_within_success() {
+        assertEquals(Outcome.SUCCESS, InRange(1, 10).validate(5).outcome())
+    }
+
+    @Test
+    fun inRange_below_error() {
+        assertEquals(Outcome.ERROR, InRange(1, 10).validate(0).outcome())
+    }
+
+    @Test
+    fun inRange_above_error() {
+        assertEquals(Outcome.ERROR, InRange(1, 10).validate(11).outcome())
+    }
+}

--- a/library/src/commonTest/kotlin/com/chrisjenx/yakcov/generic/NumericBoundRuleTest.kt
+++ b/library/src/commonTest/kotlin/com/chrisjenx/yakcov/generic/NumericBoundRuleTest.kt
@@ -45,6 +45,17 @@ class NumericBoundRuleTest {
         assertEquals(Outcome.SUCCESS, Min(2.5).validate(2.5).outcome())
     }
 
+    @Test
+    fun bounds_treat_nan_as_passthrough_consistently() {
+        // NaN is not meaningfully comparable; treat it like null/absent across all three rules
+        // (also matches the String MinValue/MaxValue behavior) so Min/Max/InRange agree.
+        assertEquals(Outcome.SUCCESS, Min(0.0).validate(Double.NaN).outcome())
+        assertEquals(Outcome.SUCCESS, Max(100.0).validate(Double.NaN).outcome())
+        assertEquals(Outcome.SUCCESS, InRange(1.0, 10.0).validate(Double.NaN).outcome())
+        assertEquals(Outcome.SUCCESS, Min(0f).validate(Float.NaN).outcome())
+        assertEquals(Outcome.SUCCESS, Max(0f).validate(Float.NaN).outcome())
+    }
+
     // --- Max ---
 
     @Test
@@ -62,6 +73,20 @@ class NumericBoundRuleTest {
         assertEquals(Outcome.ERROR, Max(10).validate(11).outcome())
     }
 
+    @Test
+    fun max_below_bound_success() {
+        assertEquals(Outcome.SUCCESS, Max(10).validate(5).outcome())
+    }
+
+    @Test
+    fun max_reacts_to_state() {
+        val bound = mutableStateOf(10)
+        val rule = Max(bound)
+        assertEquals(Outcome.ERROR, rule.validate(11).outcome())
+        bound.value = 12
+        assertEquals(Outcome.SUCCESS, rule.validate(11).outcome())
+    }
+
     // --- InRange ---
 
     @Test
@@ -72,6 +97,18 @@ class NumericBoundRuleTest {
     @Test
     fun inRange_within_success() {
         assertEquals(Outcome.SUCCESS, InRange(1, 10).validate(5).outcome())
+    }
+
+    @Test
+    fun inRange_at_min_success() {
+        // inclusive lower bound — pins < vs <=
+        assertEquals(Outcome.SUCCESS, InRange(1, 10).validate(1).outcome())
+    }
+
+    @Test
+    fun inRange_at_max_success() {
+        // inclusive upper bound — pins > vs >=
+        assertEquals(Outcome.SUCCESS, InRange(1, 10).validate(10).outcome())
     }
 
     @Test

--- a/library/src/commonTest/kotlin/com/chrisjenx/yakcov/strings/HexColorRuleTest.kt
+++ b/library/src/commonTest/kotlin/com/chrisjenx/yakcov/strings/HexColorRuleTest.kt
@@ -1,0 +1,56 @@
+package com.chrisjenx.yakcov.strings
+
+import com.chrisjenx.yakcov.ValidationResult.Outcome
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class HexColorRuleTest {
+
+    @Test
+    fun hexColor_empty_success() {
+        // blank short-circuits to success; Required owns emptiness
+        assertEquals(Outcome.SUCCESS, HexColor.validate("").outcome())
+    }
+
+    @Test
+    fun hexColor_six_digit_success() {
+        assertEquals(Outcome.SUCCESS, HexColor.validate("#ff8800").outcome())
+    }
+
+    @Test
+    fun hexColor_three_digit_success() {
+        assertEquals(Outcome.SUCCESS, HexColor.validate("#f80").outcome())
+    }
+
+    @Test
+    fun hexColor_four_digit_alpha_success() {
+        assertEquals(Outcome.SUCCESS, HexColor.validate("#f80a").outcome())
+    }
+
+    @Test
+    fun hexColor_eight_digit_alpha_success() {
+        assertEquals(Outcome.SUCCESS, HexColor.validate("#ff8800cc").outcome())
+    }
+
+    @Test
+    fun hexColor_uppercase_success() {
+        assertEquals(Outcome.SUCCESS, HexColor.validate("#FFAABB").outcome())
+    }
+
+    @Test
+    fun hexColor_missing_hash_error() {
+        assertEquals(Outcome.ERROR, HexColor.validate("ff8800").outcome())
+    }
+
+    @Test
+    fun hexColor_non_hex_chars_error() {
+        assertEquals(Outcome.ERROR, HexColor.validate("#gggggg").outcome())
+    }
+
+    @Test
+    fun hexColor_wrong_length_error() {
+        // 5 and 7 digits are not valid CSS hex color lengths
+        assertEquals(Outcome.ERROR, HexColor.validate("#fffff").outcome())
+        assertEquals(Outcome.ERROR, HexColor.validate("#fffffff").outcome())
+    }
+}

--- a/library/src/commonTest/kotlin/com/chrisjenx/yakcov/strings/HexColorRuleTest.kt
+++ b/library/src/commonTest/kotlin/com/chrisjenx/yakcov/strings/HexColorRuleTest.kt
@@ -38,6 +38,19 @@ class HexColorRuleTest {
     }
 
     @Test
+    fun hexColor_whitespace_only_success() {
+        // pins isBlank() (not isEmpty()) short-circuit
+        assertEquals(Outcome.SUCCESS, HexColor.validate("   ").outcome())
+    }
+
+    @Test
+    fun hexColor_leading_space_error() {
+        // the regex is anchored; surrounding whitespace is not trimmed
+        assertEquals(Outcome.ERROR, HexColor.validate(" #ff8800").outcome())
+        assertEquals(Outcome.ERROR, HexColor.validate("#ff8800 ").outcome())
+    }
+
+    @Test
     fun hexColor_missing_hash_error() {
         assertEquals(Outcome.ERROR, HexColor.validate("ff8800").outcome())
     }

--- a/library/src/commonTest/kotlin/com/chrisjenx/yakcov/strings/OneOfRuleTest.kt
+++ b/library/src/commonTest/kotlin/com/chrisjenx/yakcov/strings/OneOfRuleTest.kt
@@ -39,6 +39,18 @@ class OneOfRuleTest {
     }
 
     @Test
+    fun oneOf_case_sensitive_exact_match_success() {
+        // ignoreCase=false must still succeed on an exact-case match (not just error)
+        assertEquals(Outcome.SUCCESS, OneOf(setOf("US"), ignoreCase = false).validate("US").outcome())
+    }
+
+    @Test
+    fun oneOf_trims_allowed_entries_too_success() {
+        // trim applies to both the input and each allowed entry
+        assertEquals(Outcome.SUCCESS, OneOf(setOf("  US  ")).validate("US").outcome())
+    }
+
+    @Test
     fun oneOf_no_trim_error() {
         assertEquals(Outcome.ERROR, OneOf(setOf("US"), trim = false).validate(" US ").outcome())
     }

--- a/library/src/commonTest/kotlin/com/chrisjenx/yakcov/strings/OneOfRuleTest.kt
+++ b/library/src/commonTest/kotlin/com/chrisjenx/yakcov/strings/OneOfRuleTest.kt
@@ -1,0 +1,54 @@
+package com.chrisjenx.yakcov.strings
+
+import androidx.compose.runtime.mutableStateOf
+import com.chrisjenx.yakcov.ValidationResult.Outcome
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class OneOfRuleTest {
+
+    @Test
+    fun oneOf_exact_match_success() {
+        assertEquals(Outcome.SUCCESS, OneOf(setOf("US", "GB")).validate("US").outcome())
+    }
+
+    @Test
+    fun oneOf_ignore_case_success_by_default() {
+        assertEquals(Outcome.SUCCESS, OneOf(setOf("US", "GB")).validate("us").outcome())
+    }
+
+    @Test
+    fun oneOf_trims_input_by_default_success() {
+        assertEquals(Outcome.SUCCESS, OneOf(setOf("US", "GB")).validate("  US  ").outcome())
+    }
+
+    @Test
+    fun oneOf_not_in_set_error() {
+        assertEquals(Outcome.ERROR, OneOf(setOf("US", "GB")).validate("FR").outcome())
+    }
+
+    @Test
+    fun oneOf_empty_success() {
+        // blank short-circuits; Required owns emptiness
+        assertEquals(Outcome.SUCCESS, OneOf(setOf("US", "GB")).validate("").outcome())
+    }
+
+    @Test
+    fun oneOf_case_sensitive_error() {
+        assertEquals(Outcome.ERROR, OneOf(setOf("US"), ignoreCase = false).validate("us").outcome())
+    }
+
+    @Test
+    fun oneOf_no_trim_error() {
+        assertEquals(Outcome.ERROR, OneOf(setOf("US"), trim = false).validate(" US ").outcome())
+    }
+
+    @Test
+    fun oneOf_reacts_to_state() {
+        val allowed = mutableStateOf(setOf("US"))
+        val rule = OneOf(allowed)
+        assertEquals(Outcome.ERROR, rule.validate("GB").outcome())
+        allowed.value = setOf("US", "GB")
+        assertEquals(Outcome.SUCCESS, rule.validate("GB").outcome())
+    }
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -49,5 +49,6 @@ nav:
       - MVI / UDF: patterns/mvi.md
       - Circuit: patterns/circuit.md
   - Recipes:
+      - Built-in rules: recipes/built-in-rules.md
       - Custom rules: recipes/custom-rules.md
       - Phone validation: recipes/phone.md

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -78,6 +78,7 @@ release_channel() {
         print_channel "$channel" "[DRY RUN] Would patch libs.versions.toml"
         print_channel "$channel" "[DRY RUN] Would build and publish with version: $tag"
         print_channel "$channel" "[DRY RUN] Would create and push git tag: $tag"
+        print_channel "$channel" "[DRY RUN] Would create GitHub Release: $tag"
         return 0
     fi
 
@@ -108,6 +109,19 @@ release_channel() {
     git tag "$tag"
     print_channel "$channel" "Pushing tag to remote"
     git push origin "$tag"
+
+    # Create a GitHub Release for the tag — a pushed tag is not a Release on its own. Prerelease
+    # keys off the channel (the next/prerelease channel), not the tag's "-N" collision suffix.
+    # Non-fatal: the artifact is already on Maven Central and the tag is pushed.
+    if command -v gh >/dev/null 2>&1; then
+        local prerelease=""
+        if [ "$channel" != "stable" ]; then prerelease="--prerelease"; fi
+        print_channel "$channel" "Creating GitHub Release: $tag"
+        gh release create "$tag" --title "$tag" --generate-notes --verify-tag $prerelease \
+            || print_channel "$channel" "WARN: gh release create failed — tag is pushed, create the Release manually"
+    else
+        print_channel "$channel" "gh CLI not found — skipping GitHub Release (tag pushed); install gh or create it manually"
+    fi
 
     print_channel "$channel" "Released successfully: $tag"
     return 0


### PR DESCRIPTION
## Summary

Upstreams a sweep of generic validation rules a downstream consumer hand-rolled (so it can delete its local copies), fixes a correctness bug found en route, hardens CI, and documents it all. Every rule was built RED→GREEN; the diff was run through an adversarial review + a simplify pass.

## Library — new rules

| # | Rule | Notes |
|---|------|-------|
| #31 | `Optional<V>` / `ValueValidatorRule.onlyWhen(...)` | Conditional combinator — runs a wrapped rule only while a `State<Boolean>` is true; collapses 3 downstream rules. Root package, composes with string **and** generic rules. |
| #32 | generic `Min`/`Max`/`InRange` | Typed bounds on `N? where N : Number, Comparable<N>`; `null` and `NaN` pass through (presence is owned by `Required`). Reuses the `ruleMinValue`/`ruleMaxValue` messages. |
| #33 | `HexColor` | CSS `#RGB` / `#RGBA` / `#RRGGBB` / `#RRGGBBAA`, case-insensitive. |
| #34 | `OneOf(State<Set<String>>, ignoreCase, trim)` | Normalized string membership (trim + ignore-case by default). |
| #35a | `supportingText(default)` | Optional fallback hint on `ValueValidator.supportingText()` and `FieldValidationState.text()`/`supportingText()`; `default = null` reproduces the old behavior exactly. |

### ⚠️ Behavior change — `generic.InList` was inverted

`generic.InList` previously returned **ERROR when the value *was* in the list** (an effective blocklist) and SUCCESS otherwise — the opposite of its name and its "Not valid value" message. It now passes when the value is a member (or null) and errors otherwise. Kept as its own commit (`fix: generic InList was inverted …`). **Please call this out in the next release's notes** — it silently flips outcomes for any consumer that relied on the old behavior (no compile break to signal it).

## CI (#23) — off Node 20, pinned to SHAs

Every action across `checks/release/docs/track-compose` was on a Node-20 runtime. Bumped each to its latest **Node-24** release and pinned to a full commit SHA (with a `# vX.Y.Z` comment) for supply-chain safety:

- `actions/checkout` v4 → v7.0.0
- `actions/setup-java` v4.2.1 → v5.3.0
- `actions/setup-python` v5 → v6.2.0
- `browser-actions/setup-chrome` v1.7.2 → v2.1.2
- `mikepenz/action-junit-report` v4 → v6.4.1
- `peter-evans/create-pull-request` v7 → v8.1.1

`setup-chrome` v2 defaults to "Chrome for Testing" (binary no longer necessarily `google-chrome`), so the JS/Wasm steps now set `CHROME_BIN` to the action's `chrome-path` output rather than relying on PATH name resolution.

## Docs

- New **Built-in rules** reference page (`recipes/built-in-rules.md`) cataloguing every rule, including the additions, wired into the nav.
- Compiled, CI-checked example snippets in `docs-examples/Recipes.kt` for `onlyWhen` and the typed generic bounds.
- `getting-started` notes `supportingText(default)`; cross-links added.

## Testing

- New rules unit-tested via `validate().outcome()` (`kotlin.test`); `supportingText(default)` via `runComposeUiTest`.
- `:library:allTests` green on **all 5 targets** (Android, JVM, iOS-Native, JS, Wasm); 133 JVM tests.
- `docs-examples` compiles; `mkdocs build --strict` passes.

## Deferred (valid, separate efforts)

- #34 region-aware `PostalCode` (unbounded regex-table maintenance — `OneOf` covers the country-code-in-set need now)
- #35b money/`Currency` rule (needs design — pluggable locale parser/formatter)
- #11 global defaults (underspecified), #26 KMP-plugin migration, #21 Dokka

Closes #23, #31, #32, #33. Addresses #34 and #35 (PostalCode / money rule deferred — see above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
