### PR TITLE
Fix #37: MinLength passes blank + rule-convention tooling

### DIFF
--- a/docs-examples/src/commonMain/kotlin/com/chrisjenx/yakcov/docs/recipes/Recipes.kt
+++ b/docs-examples/src/commonMain/kotlin/com/chrisjenx/yakcov/docs/recipes/Recipes.kt
@@ -92,6 +92,15 @@ fun taxIdRules(isBusiness: State<Boolean>): List<ValueValidatorRule<String>> =
     listOf(Required.onlyWhen(isBusiness), MinLength(9).onlyWhen(isBusiness))
 // --8<-- [end:conditional]
 
+// --8<-- [start:optional-min-length]
+// "Optional, but at least N chars if the user types something." Gate only Required by the
+// state; leave MinLength ungated. Required.onlyWhen owns the empty case (blank passes when
+// not required), while the ungated MinLength still rejects a too-short value once typed —
+// because every string rule treats blank as valid and defers emptiness to Required.
+fun nicknameRules(required: State<Boolean>): List<ValueValidatorRule<String>> =
+    listOf(Required.onlyWhen(required), MinLength(3))
+// --8<-- [end:optional-min-length]
+
 // --8<-- [start:generic-bounds]
 @Composable
 fun QuantityField() {

--- a/docs/recipes/built-in-rules.md
+++ b/docs/recipes/built-in-rules.md
@@ -5,11 +5,14 @@ implements `ValueValidatorRule<V>`; drop them into a validator's `rules` list. T
 own, see [custom rules](custom-rules.md).
 
 !!! note "Blank / null pass through"
-    The string rules treat **blank** input as valid, and the value-membership/bounds generic
-    rules (`InList`, `Min`, `Max`, `InRange`) treat **null** as valid — so `Required` (or
-    generic `Required`) is the single source of presence-checking. `listOf(Email)` accepts an
-    empty field; `listOf(Required, Email)` doesn't. (`ListNotEmpty` and `IsChecked` are
-    themselves presence/state checks and reject null.)
+    The string **format** rules treat **blank** input as valid (`MinLength` included, as of this
+    fix), and the value-membership/bounds generic rules (`InList`, `Min`, `Max`, `InRange`) treat
+    **null** as valid — so `Required` (or generic `Required`) is the single source of
+    presence-checking. Compose it alongside the rule whenever an empty field should be rejected:
+    `listOf(Email)` accepts an empty field, `listOf(Required, Email)` doesn't. The presence/state
+    checks (`Required`, `ListNotEmpty`, `IsChecked`) and the date-part rules
+    (`DayValidation`/`MonthValidation`/`YearValidation`, which need a value to parse) are the
+    exceptions — they reject blank/null.
 
 ## String rules
 
@@ -60,6 +63,15 @@ conditionally-required or optional-when-hidden fields instead of writing a bespo
 
 ```kotlin
 --8<-- "docs-examples/src/commonMain/kotlin/com/chrisjenx/yakcov/docs/recipes/Recipes.kt:conditional"
+```
+
+For **"optional, but at least N chars if the user types something"**, gate only `Required` and
+leave the length rule ungated — `Required.onlyWhen(state)` owns the empty case while the ungated
+`MinLength` still enforces length once a value is typed (because blank always passes through to
+`Required`):
+
+```kotlin
+--8<-- "docs-examples/src/commonMain/kotlin/com/chrisjenx/yakcov/docs/recipes/Recipes.kt:optional-min-length"
 ```
 
 ## Severities

--- a/docs/recipes/built-in-rules.md
+++ b/docs/recipes/built-in-rules.md
@@ -5,8 +5,8 @@ implements `ValueValidatorRule<V>`; drop them into a validator's `rules` list. T
 own, see [custom rules](custom-rules.md).
 
 !!! note "Blank / null pass through"
-    The string **format** rules treat **blank** input as valid (`MinLength` included, as of this
-    fix), and the value-membership/bounds generic rules (`InList`, `Min`, `Max`, `InRange`) treat
+    The string **format** rules treat **blank** input as valid (`MinLength` included), and the
+    value-membership/bounds generic rules (`InList`, `Min`, `Max`, `InRange`) treat
     **null** as valid — so `Required` (or generic `Required`) is the single source of
     presence-checking. Compose it alongside the rule whenever an empty field should be rejected:
     `listOf(Email)` accepts an empty field, `listOf(Required, Email)` doesn't. The presence/state

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,6 +7,8 @@ agp = "9.1.1"
 androidx-activityCompose = "1.13.0"
 androidx-uiTest = "1.11.2"
 circuit = "0.33.1"
+# JVM-test-only: classpath scanning for the rule-convention discovery guard (RuleRegistryGuardTest)
+classgraph = "4.8.179"
 # https://github.com/JetBrains/compose-multiplatform/releases
 compose = "1.11.1"
 compose-material3 = "1.11.0-alpha07"
@@ -34,6 +36,7 @@ androidx-startup-runtime = { module = "androidx.startup:startup-runtime", versio
 androidx-testManifest = { module = "androidx.compose.ui:ui-test-manifest", version.ref = "androidx-uiTest" }
 androidx-ui = { group = "androidx.compose.ui", name = "ui" }
 circuit-foundation = { module = "com.slack.circuit:circuit-foundation", version.ref = "circuit" }
+classgraph = { module = "io.github.classgraph:classgraph", version.ref = "classgraph" }
 androidx-ui-graphics = { group = "androidx.compose.ui", name = "ui-graphics" }
 androidx-ui-tooling = { group = "androidx.compose.ui", name = "ui-tooling" }
 androidx-ui-tooling-preview = { group = "androidx.compose.ui", name = "ui-tooling-preview" }

--- a/library/build.gradle.kts
+++ b/library/build.gradle.kts
@@ -115,6 +115,8 @@ kotlin {
         }
         jvmTest.dependencies {
             implementation(compose.desktop.currentOs)
+            // Classpath scanning for RuleRegistryGuardTest (rule-convention discovery guard)
+            implementation(libs.classgraph)
         }
 
         jsMain.dependencies {

--- a/library/src/commonMain/kotlin/com/chrisjenx/yakcov/strings/StringValueValidatorRules.kt
+++ b/library/src/commonMain/kotlin/com/chrisjenx/yakcov/strings/StringValueValidatorRules.kt
@@ -106,6 +106,11 @@ data class MaxValue(val maxValue: State<Number>) : ValueValidatorRule<String> {
 }
 
 /**
+ * Validates that the string is at least [minLength] long. Blank passes ([Required] owns
+ * emptiness) — compose with [Required] to reject empty, or use `Required.onlyWhen(state)`
+ * alongside `MinLength(n)` for an optional field that must be at least `n` chars *if* the user
+ * types something.
+ *
  * @param trim if true will trim the start and end before checking the length
  * @param includeWhiteSpace if false will not count white space chars in this string.
  *  As defined by [Char.isWhitespace]
@@ -126,6 +131,8 @@ data class MinLength(
     private val _trim by trim
     private val _includeWhiteSpace by includeWhiteSpace
     override fun validate(value: String): ValidationResult {
+        // only validate if not empty as Required will check if not empty
+        if (value.isBlank()) return ResourceValidationResult.success()
         val trimmed = value.let { if (_trim) it.trim() else it }
         return when {
             _includeWhiteSpace && trimmed.length < _minLength -> {

--- a/library/src/commonMain/kotlin/com/chrisjenx/yakcov/strings/StringValueValidatorRules.kt
+++ b/library/src/commonMain/kotlin/com/chrisjenx/yakcov/strings/StringValueValidatorRules.kt
@@ -107,7 +107,7 @@ data class MaxValue(val maxValue: State<Number>) : ValueValidatorRule<String> {
 
 /**
  * Validates that the string is at least [minLength] long. Blank passes ([Required] owns
- * emptiness) — compose with [Required] to reject empty, or use `Required.onlyWhen(state)`
+ * emptiness) — compose with [Required] to reject blank, or use `Required.onlyWhen(state)`
  * alongside `MinLength(n)` for an optional field that must be at least `n` chars *if* the user
  * types something.
  *

--- a/library/src/commonTest/kotlin/com/chrisjenx/yakcov/RuleCombinatorsTest.kt
+++ b/library/src/commonTest/kotlin/com/chrisjenx/yakcov/RuleCombinatorsTest.kt
@@ -53,4 +53,22 @@ class RuleCombinatorsTest {
         enabled.value = false
         assertEquals(Outcome.SUCCESS, MinLength(8).onlyWhen(enabled).validate("abc").outcome())
     }
+
+    @Test
+    fun optionalMinLength_idiom_blankPassesButShortValueStillFails() {
+        // "optional, but >= 3 chars if typed" = Required gated by `required` + an ungated MinLength.
+        // Required.onlyWhen owns the empty case; the ungated MinLength always enforces length once typed.
+        val required = mutableStateOf(false)
+        val gate = Required.onlyWhen(required)
+        val min = MinLength(3)
+        // not required + blank -> both rules pass
+        assertEquals(Outcome.SUCCESS, gate.validate("").outcome())
+        assertEquals(Outcome.SUCCESS, min.validate("").outcome())
+        // not required + a short value typed -> MinLength still rejects it
+        assertEquals(Outcome.SUCCESS, gate.validate("ab").outcome())
+        assertEquals(Outcome.ERROR, min.validate("ab").outcome())
+        // becomes required -> Required catches the empty case
+        required.value = true
+        assertEquals(Outcome.ERROR, gate.validate("").outcome())
+    }
 }

--- a/library/src/commonTest/kotlin/com/chrisjenx/yakcov/RuleConventions.kt
+++ b/library/src/commonTest/kotlin/com/chrisjenx/yakcov/RuleConventions.kt
@@ -1,0 +1,97 @@
+package com.chrisjenx.yakcov
+
+import com.chrisjenx.yakcov.strings.Decimal
+import com.chrisjenx.yakcov.strings.Email
+import com.chrisjenx.yakcov.strings.HexColor
+import com.chrisjenx.yakcov.strings.MaxLength
+import com.chrisjenx.yakcov.strings.MaxValue
+import com.chrisjenx.yakcov.strings.MinLength
+import com.chrisjenx.yakcov.strings.MinValue
+import com.chrisjenx.yakcov.strings.Numeric
+import com.chrisjenx.yakcov.strings.OneOf
+import com.chrisjenx.yakcov.strings.Phone
+import com.chrisjenx.yakcov.strings.PhoneFormat
+import com.chrisjenx.yakcov.strings.Required
+
+/**
+ * Catalog of the rule conventions, used by [RuleConventionsTest] (behaviour) and the JVM-only
+ * `RuleRegistryGuardTest` (completeness — every concrete `ValueValidatorRule` in the
+ * `com.chrisjenx.yakcov` package tree must appear in exactly one bucket here).
+ *
+ * The library convention is **"blank passes — `Required` owns emptiness"**: a string format rule
+ * short-circuits `if (value.isBlank()) return success()`, and the generic membership/bounds rules
+ * do the same for `null`. Presence is composed separately via `Required`.
+ *
+ * When you add a new rule, classify it into exactly one bucket below. The discovery guard fails
+ * the build until you do, so the convention can't silently rot (the bug behind issue #37, where
+ * `MinLength` was the lone string rule that rejected blank).
+ *
+ * String rules are held as instances so [RuleConventionsTest] can call `validate` on them; generic
+ * rules carry type parameters that resist a shared list, so they are tracked here by name and
+ * asserted individually in [RuleConventionsTest] — keep the two in sync.
+ *
+ * Rules are tracked by **simple name** so the catalog can stay cross-platform (`qualifiedName` is
+ * JVM-only). The two `Required` rules (`strings.Required` and `generic.Required`) intentionally
+ * share the name "Required" — both reject emptiness, so collapsing them is correct; the guard fails
+ * on any *other* simple-name collision.
+ */
+object RuleConventions {
+
+    /**
+     * String rules that defer emptiness to `Required`: an empty `""` field must pass. All but
+     * [MaxLength] do so via an explicit `if (value.isBlank()) return success()` short-circuit, so
+     * they also pass whitespace-only input. [MaxLength] passes `""` only because length 0 is within
+     * any bound (it has no blank guard), so the whitespace-only guarantee is asserted for the others
+     * — see [RuleConventionsTest].
+     */
+    val emptyPassesStringRules: List<ValueValidatorRule<String>> = listOf(
+        Numeric,
+        Decimal,
+        MinValue(1),
+        MaxValue(1),
+        MinLength(3),
+        MaxLength(3),
+        Email,
+        HexColor,
+        OneOf(setOf("US")),
+        Phone("US"),
+        PhoneFormat,
+    )
+
+    /** Presence string rules: blank must be rejected (the inverse of the convention). */
+    val emptyRejectedStringRules: List<ValueValidatorRule<String>> = listOf(
+        Required,
+    )
+
+    // Generic rules carry type parameters that resist a single shared list, so they are asserted
+    // individually in RuleConventionsTest; the discovery guard tracks them by simple name here.
+
+    /** Generic membership/bounds rules whose `null` must pass — `Required` owns presence. */
+    val emptyPassesGenericRuleNames: Set<String> = setOf("InList", "Min", "Max", "InRange")
+
+    /** Generic presence/state rules whose `null` must be rejected. */
+    val emptyRejectedGenericRuleNames: Set<String> = setOf("Required", "ListNotEmpty", "IsChecked")
+
+    /**
+     * Rules deliberately exempt from the empty-passes convention. Each needs a reason — these are
+     * the conscious exceptions the discovery guard makes you opt into rather than forget.
+     */
+    val exemptRuleNames: Set<String> = setOf(
+        // Parse a required numeric date component; blank is genuinely invalid, not merely "absent".
+        "DayValidation", "MonthValidation", "YearValidation",
+        // Identity checks against a sibling field; emptiness validity depends on the other field.
+        "PasswordMatchesString", "PasswordMatchesTextFieldValue",
+        // Inverse boolean state check; null/false pass and only `true` fails — not an emptiness gate.
+        "IsNotChecked",
+        // Combinator (onlyWhen/Optional): delegates blank/null handling to the rule it wraps, so it
+        // has no emptiness convention of its own.
+        "Optional",
+    )
+
+    /** Every concrete rule simple-name the discovery guard expects to find on the classpath. */
+    val coveredRuleSimpleNames: Set<String> =
+        (emptyPassesStringRules + emptyRejectedStringRules).mapNotNull { it::class.simpleName }.toSet() +
+            emptyPassesGenericRuleNames +
+            emptyRejectedGenericRuleNames +
+            exemptRuleNames
+}

--- a/library/src/commonTest/kotlin/com/chrisjenx/yakcov/RuleConventionsTest.kt
+++ b/library/src/commonTest/kotlin/com/chrisjenx/yakcov/RuleConventionsTest.kt
@@ -1,0 +1,79 @@
+package com.chrisjenx.yakcov
+
+import com.chrisjenx.yakcov.ValidationResult.Outcome
+import com.chrisjenx.yakcov.generic.InList
+import com.chrisjenx.yakcov.generic.InRange
+import com.chrisjenx.yakcov.generic.IsChecked
+import com.chrisjenx.yakcov.generic.ListNotEmpty
+import com.chrisjenx.yakcov.generic.Max
+import com.chrisjenx.yakcov.generic.Min
+import com.chrisjenx.yakcov.strings.MaxLength
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import com.chrisjenx.yakcov.generic.Required as GenericRequired
+
+/**
+ * Cross-platform behavioural contract for the "blank passes — `Required` owns emptiness"
+ * convention, driven by the [RuleConventions] catalog. Runs on every platform's test leg.
+ *
+ * Completeness (every rule on the classpath is classified here) is enforced separately by the
+ * JVM-only `RuleRegistryGuardTest`, which can use reflection.
+ */
+class RuleConventionsTest {
+
+    @Test
+    fun emptyPassesStringRules_passEmpty() {
+        // The canonical "absent field" is "". Every defer-to-Required string rule must pass it.
+        // This is what catches the #37 regression (MinLength(3).validate("") used to ERROR).
+        RuleConventions.emptyPassesStringRules.forEach { rule ->
+            assertEquals(
+                Outcome.SUCCESS, rule.validate("").outcome(),
+                "${rule::class.simpleName} should pass an empty string (Required owns emptiness)"
+            )
+        }
+    }
+
+    @Test
+    fun blankGuardedStringRules_passWhitespaceOnly() {
+        // Whitespace-only is non-empty but blank, so it specifically exercises the
+        // `if (value.isBlank())` short-circuit. MaxLength is excluded: it has no such guard (it
+        // passes "" only because length 0 is within bound), so an over-long whitespace string
+        // legitimately fails its length cap.
+        RuleConventions.emptyPassesStringRules
+            .filterNot { it is MaxLength }
+            .forEach { rule ->
+                assertEquals(
+                    Outcome.SUCCESS, rule.validate("   ").outcome(),
+                    "${rule::class.simpleName} should pass a whitespace-only string"
+                )
+            }
+    }
+
+    @Test
+    fun emptyRejectedStringRules_rejectBlank() {
+        RuleConventions.emptyRejectedStringRules.forEach { rule ->
+            assertEquals(
+                Outcome.ERROR, rule.validate("").outcome(),
+                "${rule::class.simpleName} should reject an empty string"
+            )
+        }
+    }
+
+    @Test
+    fun emptyPassesGenericRules_passNull() {
+        assertEquals(Outcome.SUCCESS, InList(listOf(1)).validate(null).outcome(), "InList should pass null")
+        assertEquals(Outcome.SUCCESS, Min(1).validate(null).outcome(), "Min should pass null")
+        assertEquals(Outcome.SUCCESS, Max(1).validate(null).outcome(), "Max should pass null")
+        assertEquals(Outcome.SUCCESS, InRange(1, 2).validate(null).outcome(), "InRange should pass null")
+    }
+
+    @Test
+    fun emptyRejectedGenericRules_rejectNull() {
+        assertEquals(Outcome.ERROR, GenericRequired<Any>().validate(null).outcome(), "Required should reject null")
+        assertEquals(
+            Outcome.ERROR, ListNotEmpty<List<Any>?>().validate(null).outcome(),
+            "ListNotEmpty should reject null"
+        )
+        assertEquals(Outcome.ERROR, IsChecked.validate(null).outcome(), "IsChecked should reject null")
+    }
+}

--- a/library/src/commonTest/kotlin/com/chrisjenx/yakcov/RuleConventionsTest.kt
+++ b/library/src/commonTest/kotlin/com/chrisjenx/yakcov/RuleConventionsTest.kt
@@ -51,10 +51,14 @@ class RuleConventionsTest {
 
     @Test
     fun emptyRejectedStringRules_rejectBlank() {
+        // The convention is about *blank* (isBlank), so presence rules must reject both an empty
+        // string and a whitespace-only one.
         RuleConventions.emptyRejectedStringRules.forEach { rule ->
+            val name = rule::class.simpleName
+            assertEquals(Outcome.ERROR, rule.validate("").outcome(), "$name should reject an empty string")
             assertEquals(
-                Outcome.ERROR, rule.validate("").outcome(),
-                "${rule::class.simpleName} should reject an empty string"
+                Outcome.ERROR, rule.validate("   ").outcome(),
+                "$name should reject a whitespace-only string (blank, not just empty)"
             )
         }
     }

--- a/library/src/commonTest/kotlin/com/chrisjenx/yakcov/strings/MinLengthRuleTest.kt
+++ b/library/src/commonTest/kotlin/com/chrisjenx/yakcov/strings/MinLengthRuleTest.kt
@@ -1,0 +1,66 @@
+package com.chrisjenx.yakcov.strings
+
+import com.chrisjenx.yakcov.ValidationResult.Outcome
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class MinLengthRuleTest {
+
+    @Test
+    fun minLength_empty_success() {
+        // blank short-circuits to success; Required owns emptiness
+        assertEquals(Outcome.SUCCESS, MinLength(3).validate("").outcome())
+    }
+
+    @Test
+    fun minLength_whitespace_only_success_with_trim() {
+        // default trim=true: a whitespace-only value is blank and passes
+        assertEquals(Outcome.SUCCESS, MinLength(3).validate("   ").outcome())
+    }
+
+    @Test
+    fun minLength_whitespace_only_success_without_trim() {
+        // even with trim=false, isBlank() short-circuits whitespace-only input
+        assertEquals(Outcome.SUCCESS, MinLength(5, trim = false).validate("   ").outcome())
+    }
+
+    @Test
+    fun minLength_short_value_error() {
+        // a non-blank value shorter than the minimum still fails
+        assertEquals(Outcome.ERROR, MinLength(3).validate("ab").outcome())
+    }
+
+    @Test
+    fun minLength_exact_length_success() {
+        assertEquals(Outcome.SUCCESS, MinLength(3).validate("abc").outcome())
+    }
+
+    @Test
+    fun minLength_over_length_success() {
+        assertEquals(Outcome.SUCCESS, MinLength(3).validate("abcd").outcome())
+    }
+
+    @Test
+    fun minLength_trim_counts_trimmed_length() {
+        // surrounding whitespace is trimmed before measuring, so "ab" (len 2) fails MinLength(3)
+        assertEquals(Outcome.ERROR, MinLength(3, trim = true).validate("  ab  ").outcome())
+    }
+
+    @Test
+    fun minLength_includeWhiteSpace_false_counts_non_whitespace() {
+        // "a b" has 2 non-whitespace chars, which is < 3
+        assertEquals(
+            Outcome.ERROR,
+            MinLength(3, includeWhiteSpace = false).validate("a b").outcome()
+        )
+    }
+
+    @Test
+    fun minLength_includeWhiteSpace_false_success() {
+        // "a b c" has 3 non-whitespace chars
+        assertEquals(
+            Outcome.SUCCESS,
+            MinLength(3, includeWhiteSpace = false).validate("a b c").outcome()
+        )
+    }
+}

--- a/library/src/jvmTest/kotlin/com/chrisjenx/yakcov/RuleRegistryGuardTest.kt
+++ b/library/src/jvmTest/kotlin/com/chrisjenx/yakcov/RuleRegistryGuardTest.kt
@@ -1,0 +1,87 @@
+package com.chrisjenx.yakcov
+
+import io.github.classgraph.ClassGraph
+import kotlin.test.Test
+import kotlin.test.assertTrue
+import kotlin.test.fail
+
+/**
+ * JVM-only completeness guard for [RuleConventions]: classpath-scans the whole `com.chrisjenx.yakcov`
+ * package tree (strings, generic, and combinators in the root package) and fails if any concrete
+ * [ValueValidatorRule] is missing from the catalog. This is the half of the convention tooling that
+ * reflection makes possible (the cross-platform behavioural contract lives in [RuleConventionsTest]).
+ *
+ * Because rule logic is common code, scanning the JVM compilation covers every platform. A new rule
+ * forces a conscious choice: classify it under the convention, or add it to `exemptRuleNames` with
+ * a reason. The build stays red until then.
+ */
+class RuleRegistryGuardTest {
+
+    // Scan the whole library package tree, not just strings/generic, so combinators in the root
+    // package (e.g. Optional) can't escape classification. The `getClassesImplementing` filter
+    // selects only rules, so test classes sharing these packages are ignored.
+    private val rulePackage = "com.chrisjenx.yakcov"
+
+    // The only simple-name collision the simple-name-keyed catalog tolerates: strings.Required and
+    // generic.Required (both reject emptiness). Any other collision is a blind spot — see below.
+    private val allowedSimpleNameCollisions = setOf("Required")
+
+    @Test
+    fun everyConcreteRuleIsClassifiedInRuleConventions() {
+        val discoveredClasses = ClassGraph()
+            .enableClassInfo()
+            .acceptPackages(rulePackage)
+            .scan()
+            .use { result ->
+                result.getClassesImplementing(ValueValidatorRule::class.java.name)
+                    .filter { info ->
+                        !info.isInterface &&
+                            !info.isAbstract &&
+                            !info.isAnonymousInnerClass &&
+                            !info.isSynthetic
+                    }
+                    .mapNotNull { it.name }
+                    .toSet()
+            }
+
+        assertTrue(
+            discoveredClasses.isNotEmpty(),
+            "ClassGraph found no rules under $rulePackage — the scan or package name is wrong"
+        )
+
+        // [RuleConventions] keys rules by simple name (so the catalog stays cross-platform). That
+        // collapses two distinct rules sharing a simple name into one entry, which would let the
+        // second ship unclassified. Fail loudly on any unexpected collision so the catalog can be
+        // switched to qualified names before that happens.
+        val collisions = discoveredClasses
+            .groupBy { it.substringAfterLast('.') }
+            .filter { (simpleName, fqns) -> fqns.size > 1 && simpleName !in allowedSimpleNameCollisions }
+        if (collisions.isNotEmpty()) {
+            fail(
+                "Rule simple-name collision(s) that RuleConventions cannot distinguish: " +
+                    "${collisions.mapValues { it.value.sorted() }}. Key the catalog by qualified name " +
+                    "or rename the rule."
+            )
+        }
+
+        val discovered = discoveredClasses.map { it.substringAfterLast('.') }.toSet()
+        val covered = RuleConventions.coveredRuleSimpleNames
+
+        val unclassified = discovered - covered
+        if (unclassified.isNotEmpty()) {
+            fail(
+                "ValueValidatorRule(s) not classified in RuleConventions: ${unclassified.sorted()}. " +
+                    "Add each to emptyPasses*/emptyRejected* if it follows the blank/null-passes " +
+                    "convention, or to exemptRuleNames with a documented reason."
+            )
+        }
+
+        val stale = covered - discovered
+        if (stale.isNotEmpty()) {
+            fail(
+                "RuleConventions lists rule name(s) that no longer exist on the classpath: " +
+                    "${stale.sorted()}. Remove the stale entries (rule renamed or deleted?)."
+            )
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Fixes **#37** — `MinLength` was the only `strings` rule that rejected blank input, breaking the library-wide **"blank passes — `Required` owns emptiness"** convention. Also adds tooling so that convention can't silently rot again.

### Fix (`fix: MinLength passes blank input`)
- `MinLength.validate` now short-circuits `if (value.isBlank()) return success()`, like every other format rule. Using `isBlank()` (not a trim-based check) also passes whitespace-only input even when `trim=false`.
- `Required.onlyWhen(state)` alongside `MinLength(n)` is now the idiom for *optional, but at least N chars if the user types something*.
- Adds `MinLengthRuleTest`, a `RuleCombinators` idiom test, a compiled docs snippet, and clarifies the convention in the KDoc and `built-in-rules.md`.

### Tooling (`test: enforce the blank-passes rule convention`)
- **`RuleConventionsTest`** (commonTest, runs on every platform): behavioural contract driven by the `RuleConventions` catalog — every defer-to-`Required` string rule passes empty; the `isBlank()`-guarded ones also pass whitespace-only (`MaxLength` excepted — it has no blank guard, passing empty only via its length bound); generic bounds pass `null`; presence rules reject.
- **`RuleRegistryGuardTest`** (jvmTest): ClassGraph scans the `com.chrisjenx.yakcov` tree and fails if any concrete `ValueValidatorRule` is unclassified — a new rule must consciously follow the convention or be added to `exemptRuleNames` with a reason. Keys by qualified name and fails on any unexpected simple-name collision.
- Adds `classgraph` as a **jvmTest-only** dependency.

No new CI config: the existing JVM leg already runs `:library:jvmTest`, and the contract test rides every platform leg via `commonTest`.

## Test plan
- `./gradlew :library:jvmTest` — green (rule, convention, and guard tests)
- `./gradlew :library:compileTestKotlinJs :library:compileTestKotlinWasmJs` — green (common contract test type-checks on non-JVM targets)
- `./gradlew :docs-examples:compileKotlinJvm` — green (the new docs snippet compiles)
- Both guards proven to fail on a violation (unclassified rule; rule misclassified as blank-passing), then reverted.

Closes #37

🤖 Generated with [Claude Code](https://claude.com/claude-code)
