### PR TITLE
feat: UDF-safe Modifier primitives + public API gate

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -113,6 +113,23 @@ jobs:
           check_name: 'JVM JUnit Test Report (${{ matrix.channel }})'
           require_tests: true
 
+  Checks-Api:
+    runs-on: ubuntu-latest
+    name: Checks-Api
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - name: Get tags
+        run: git fetch --tags origin
+      - name: Setup Java JDK
+        uses: actions/setup-java@ad2b38190b15e4d6bdf0c97fb4fca8412226d287 # v5.3.0
+        with:
+          distribution: 'zulu'
+          java-version: '21'
+          cache: 'gradle'
+      - name: Check public API
+        run: ./gradlew :library:checkLegacyAbi
+
   Checks-Apple:
     needs: Build-Matrix
     runs-on: macos-latest
@@ -153,7 +170,7 @@ jobs:
   # protection rules instead of naming each matrix leg (which change with
   # compose-releases.toml).
   CI-Gate:
-    needs: [Build-Matrix, Checks-Scripts, Checks-JS, Checks-Jvm, Checks-Apple]
+    needs: [Build-Matrix, Checks-Scripts, Checks-JS, Checks-Jvm, Checks-Apple, Checks-Api]
     if: always()
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -128,7 +128,7 @@ jobs:
           java-version: '21'
           cache: 'gradle'
       - name: Check public API
-        run: ./gradlew :library:checkLegacyAbi
+        run: ./gradlew :library:checkKotlinAbi
 
   Checks-Apple:
     needs: Build-Matrix

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,7 +79,11 @@ jobs:
           ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.SIGNING_KEY_PASSWORD }}
       - name: Dry-run build
         if: ${{ inputs.dry-run == true }}
-        run: ./gradlew :library:build --no-configuration-cache -PpublishVersion="${{ matrix.tag }}"
+        # checkKotlinAbi is excluded: library/api/ dumps are toolchain-specific (each Kotlin
+        # version emits a slightly different surface), so a dump generated on stable cannot match
+        # a non-stable channel's compiler. The unmatrixed `Checks-Api` job owns that gate and runs
+        # on every PR; re-running it here would only ever fail for the channel mismatch.
+        run: ./gradlew :library:build -x :library:checkKotlinAbi --no-configuration-cache -PpublishVersion="${{ matrix.tag }}"
       - name: Create and push git tag
         if: ${{ inputs.dry-run == false }}
         run: |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,6 +92,21 @@ Each channel may also set `track` (`stable` | `prerelease`) to declare which ups
 
 ## Key Design Decisions
 
+- **Modifier primitives are free functions over plain values.** `Modifiers.kt` owns `shakeOnInvalid`,
+  `validationBehavior`, `onFocusCursorToEnd`, and `onFocusLost` so reducer-MVI and headless
+  `FieldValidator` code can use them with no validator object; `TextFieldValueValidator`'s
+  `onFocusCursorToEnd` member keeps its signature and forwards to the free form. The bundle is called
+  `validationBehavior`, **not** `validationConfig` — the latter is a `ValueValidator` member taking a
+  leading `Boolean`, and Kotlin's member-over-extension rule would silently bind a same-named free
+  function to it (setting `validateOnFocusLost` instead of `isError`) with no compiler diagnostic.
+- **Shake: two mechanisms on disjoint classes, deliberately.** `ValueValidator` keeps its own
+  imperative shake (`validationConfig(shakeOnInvalid = true)`), untouched. The plain-value paths use
+  `shakeOnInvalid(isError, trigger)` driven by a monotonic counter — `FieldValidator.attempts`, or a
+  reducer's own `submitAttempts`. Shake is **never** driven by diffing `FieldValidationState`: its
+  equality includes the message, so repeated invalid submits compare equal and a diff-driven shake
+  would fire once and never again. Give disposable fields a stable `key`, or a re-created field adopts
+  the current counter as its baseline and swallows a due shake. Shake is visual only — a
+  `graphicsLayer` translation, silent to screen readers.
 - **All Compose dependencies are `compileOnly`** in `commonMain` to avoid forcing transitive deps on consumers. Tests use `implementation` so they actually resolve.
 - **libphonenumber-kotlin is `compileOnly`** — consumers must add it themselves only for the region-aware `Phone` rule (and the `isPhoneNumber()` helper). The default `PhoneFormat` rule and the `String?.isPhoneNumberFormat()` helper are dependency-free common code.
 - **kotlinx-serialization-core and compose runtime-saveable are `compileOnly`** — consumers who serialize `FieldValidationState` must add a serialization runtime themselves (in practice `kotlinx-serialization-json`, which pulls core transitively). `Outcome` persists by constant *name*; don't rename its constants without a migration. `FieldValidationState.result` is `@Transient` (the kotlinx `Transient`, not `kotlin.jvm`) and equality intentionally includes `result` so message-only changes still recompose.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,7 +40,13 @@ python3 scripts/check-compose-updates.py --self-test    # offline unit tests
 
 Requires JDK 17+. CI uses JDK 21 (Zulu). CI (`.github/workflows/checks.yml`) runs every platform's tests as a **matrix across both Compose channels**; the `next` (beta) leg is `continue-on-error`. The single required status check is the aggregate `CI-Gate` job — set branch protection on that, not on individual matrix legs (which change with `compose-releases.toml`). JS/WasmJS tests run through Karma with `ChromeHeadless`; if Chrome isn't auto-detected, set `CHROME_BIN` to the Chrome/Chromium binary.
 
-**Public API is gated.** `Checks-Api` (unmatrixed — public API must not vary by channel) runs `./gradlew :library:checkKotlinAbi` against the ABI dumps committed in `library/api/`, via Kotlin's built-in `abiValidation`. **Add or change a public symbol and CI fails until you run `./gradlew :library:updateKotlinAbi` and commit the dump.** `internal` declarations must not appear there. Caveat: the job runs on `ubuntu-latest`, so the Apple entries in `library.klib.api` pass by inference (`klib.keepUnsupportedTargets` defaults true) rather than being validated; js/wasmJs still catch common-API drift.
+**Public API is gated.** `Checks-Api` runs `./gradlew :library:checkKotlinAbi` against the ABI dumps committed in `library/api/`, via Kotlin's built-in `abiValidation`. **Add or change a public symbol and CI fails until you run `./gradlew :library:updateKotlinAbi` and commit the dump.** `internal` declarations must not appear there.
+
+The job is **unmatrixed, and must stay that way** — not only because public API must not vary by channel, but because the dumps are *toolchain-specific*: each Kotlin version emits a slightly different surface (2.4 stops emitting the synthetic `DefaultConstructorMarker` bridge constructors that 2.3 does), so a stable-generated dump can never match another channel's compiler. `release.yml`'s dry-run passes `-x :library:checkKotlinAbi` for the same reason. Regenerate dumps on **stable** only.
+
+Two traps in the `abiValidation` block itself (see the comment in `library/build.gradle.kts`): `enabled` must be set **reflectively**, because Kotlin 2.4 removed it and naming it statically is a deprecation-level *error* that fails the build script's own compilation on `[next]`; and an *empty* block is not a substitute — on 2.3 that leaves `checkKotlinAbi` `SKIPPED`, a gate that passes while validating nothing. Verify any change here with a mutation test: add a public symbol and confirm the check actually **fails**.
+
+Caveat: the job runs on `ubuntu-latest`, so the Apple entries in `library.klib.api` pass by inference (`klib.keepUnsupportedTargets` defaults true) rather than being validated; js/wasmJs still catch common-API drift.
 
 ## Modules
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,6 +40,8 @@ python3 scripts/check-compose-updates.py --self-test    # offline unit tests
 
 Requires JDK 17+. CI uses JDK 21 (Zulu). CI (`.github/workflows/checks.yml`) runs every platform's tests as a **matrix across both Compose channels**; the `next` (beta) leg is `continue-on-error`. The single required status check is the aggregate `CI-Gate` job — set branch protection on that, not on individual matrix legs (which change with `compose-releases.toml`). JS/WasmJS tests run through Karma with `ChromeHeadless`; if Chrome isn't auto-detected, set `CHROME_BIN` to the Chrome/Chromium binary.
 
+**Public API is gated.** `Checks-Api` (unmatrixed — public API must not vary by channel) runs `./gradlew :library:checkKotlinAbi` against the ABI dumps committed in `library/api/`, via Kotlin's built-in `abiValidation`. **Add or change a public symbol and CI fails until you run `./gradlew :library:updateKotlinAbi` and commit the dump.** `internal` declarations must not appear there. Caveat: the job runs on `ubuntu-latest`, so the Apple entries in `library.klib.api` pass by inference (`klib.keepUnsupportedTargets` defaults true) rather than being validated; js/wasmJs still catch common-API drift.
+
 ## Modules
 
 - **`:library`** — The published KMP library. All source under `library/src/`.
@@ -55,7 +57,7 @@ The core validation model is a hierarchy rooted in `ValueValidator<V, R>`:
 
 - **`GenericValueValidator<T>`** (`generic/GenericValueValidator.kt`) — Extends `ValueValidator<T, T>`. Validates any arbitrary type directly. Use `rememberGenericValueValidator()` in Compose.
 
-- **`FieldValidator<V>`** (`FieldValidator.kt`) — Headless, presenter-ownable validator with a **plain constructor** (no `@Composable`, no coroutine scope, no `Modifier` dependency) for snapshot-presenter (Molecule) screens. Owns its draft in a snapshot `value` cell and folds the `ValueValidatorRule` list into a plain `@Immutable @Serializable` `FieldValidationState` (`severity` + `showError` + a `@Transient` `ValidationResult`) via the pure `toFieldState` bridges in `FieldValidationState.kt`. It is **separate from** `ValueValidator` (not a refactor), so the existing API is untouched. An optional `observer: FieldValidatorObserver<V>` constructor param fires `ValueChanged`/`Validated`/`Reset` events after each mutation commits (never at construction; observers must not throw). **It is a mutable, reference-identity holder — do not place it inside an immutable reducer-MVI `Model`;** for reducer-MVI store the draft + `FieldValidationState` and call `toFieldState` in `reduce()`. Render messages with `FieldValidationState.text()`/`supportingText()`; submit with `List<FieldValidator<*>>.validate()` (reveals then checks).
+- **`FieldValidator<V>`** (`FieldValidator.kt`) — Headless validator with a **plain constructor** (no `@Composable`, no coroutine scope, no `Modifier` dependency) for snapshot-presenter (Molecule) screens; separate from `ValueValidator`, not a refactor of it. Holds its draft in a snapshot `value` cell and folds the rule list into an `@Immutable @Serializable` `FieldValidationState` (`severity` + `showError` + a `@Transient` `ValidationResult`) via the pure `toFieldState` bridges in `FieldValidationState.kt`. `attempts` counts submit-intent `validate()` calls only — not `onFocusLost()`, and never reset — and is this path's shake trigger. Optional `observer: FieldValidatorObserver<V>` fires `ValueChanged`/`Validated`/`Reset` after each mutation commits (never at construction; observers must not throw). **A mutable, reference-identity holder — never put it in an immutable reducer-MVI `Model`;** there, store the draft + `FieldValidationState` and call `toFieldState` in `reduce()`. Render with `FieldValidationState.text()`/`supportingText()`; submit with `List<FieldValidator<*>>.validate()` (reveals then checks).
 
 - **`ValueValidatorRule<V>`** (`ValueValidatorRule.kt`) — SAM interface. Implement `validate(value: V): ValidationResult` to create custom rules.
 
@@ -92,21 +94,8 @@ Each channel may also set `track` (`stable` | `prerelease`) to declare which ups
 
 ## Key Design Decisions
 
-- **Modifier primitives are free functions over plain values.** `Modifiers.kt` owns `shakeOnInvalid`,
-  `validationBehavior`, `onFocusCursorToEnd`, and `onFocusLost` so reducer-MVI and headless
-  `FieldValidator` code can use them with no validator object; `TextFieldValueValidator`'s
-  `onFocusCursorToEnd` member keeps its signature and forwards to the free form. The bundle is called
-  `validationBehavior`, **not** `validationConfig` — the latter is a `ValueValidator` member taking a
-  leading `Boolean`, and Kotlin's member-over-extension rule would silently bind a same-named free
-  function to it (setting `validateOnFocusLost` instead of `isError`) with no compiler diagnostic.
-- **Shake: two mechanisms on disjoint classes, deliberately.** `ValueValidator` keeps its own
-  imperative shake (`validationConfig(shakeOnInvalid = true)`), untouched. The plain-value paths use
-  `shakeOnInvalid(isError, trigger)` driven by a monotonic counter — `FieldValidator.attempts`, or a
-  reducer's own `submitAttempts`. Shake is **never** driven by diffing `FieldValidationState`: its
-  equality includes the message, so repeated invalid submits compare equal and a diff-driven shake
-  would fire once and never again. Give disposable fields a stable `key`, or a re-created field adopts
-  the current counter as its baseline and swallows a due shake. Shake is visual only — a
-  `graphicsLayer` translation, silent to screen readers.
+- **Modifier primitives are free functions over plain values.** `Modifiers.kt` owns `shakeOnInvalid`, `validationBehavior`, `onFocusCursorToEnd` and `onFocusLost`, so reducer-MVI and headless `FieldValidator` code needs no validator object; `TextFieldValueValidator.onFocusCursorToEnd` keeps its signature and forwards to the free form. The bundle is `validationBehavior`, **not** `validationConfig`: that name is a `ValueValidator` member taking a leading `Boolean`, and member-over-extension resolution would silently bind a same-named free function to it — setting `validateOnFocusLost` instead of `isError`, with no compiler diagnostic. In `validationBehavior`, `isError` gates only the shake, so it is inert when `shakeTrigger` is null.
+- **Shake: two mechanisms on disjoint classes, deliberately.** `ValueValidator` keeps its imperative shake (`validationConfig(shakeOnInvalid = true)`), untouched. Plain-value paths use `shakeOnInvalid(isError, trigger)` driven by a monotonic counter (`FieldValidator.attempts`, or a reducer's own `submitAttempts`) — **never** by diffing `FieldValidationState`, whose equality includes the message, so repeated invalid submits compare equal and a diff-driven shake would fire once and never again. `LaunchedEffect(trigger)` *cancels* an in-flight shake, so the animation is wrapped in `try`/`finally` with a `NonCancellable` `snapTo(0f)`; without it a cancelled shake leaves the field translated off-centre permanently. Give disposable fields a stable `key`, or a re-created field adopts the current counter as its baseline and swallows a due shake. Shake is visual only — a `graphicsLayer` translation, silent to screen readers.
 - **All Compose dependencies are `compileOnly`** in `commonMain` to avoid forcing transitive deps on consumers. Tests use `implementation` so they actually resolve.
 - **libphonenumber-kotlin is `compileOnly`** — consumers must add it themselves only for the region-aware `Phone` rule (and the `isPhoneNumber()` helper). The default `PhoneFormat` rule and the `String?.isPhoneNumberFormat()` helper are dependency-free common code.
 - **kotlinx-serialization-core and compose runtime-saveable are `compileOnly`** — consumers who serialize `FieldValidationState` must add a serialization runtime themselves (in practice `kotlinx-serialization-json`, which pulls core transitively). `Outcome` persists by constant *name*; don't rename its constants without a migration. `FieldValidationState.result` is `@Transient` (the kotlinx `Transient`, not `kotlin.jvm`) and equality intentionally includes `result` so message-only changes still recompose.

--- a/README.MD
+++ b/README.MD
@@ -70,11 +70,9 @@ ViewModel/presenter owns a `FieldValidator`, or a pure MVI reducer folds rules w
 
 ## Dependencies
 
-By default we publish
-to [Maven Central](https://central.sonatype.com/artifact/com.chrisjenx.yakcov/library).
-
-We publish all targets (Android, JVM, JS, Wasm, iOS) you can include the common library in your
-project and it will pull in the correct target for what ever targets you have specified.
+Published to [Maven Central](https://central.sonatype.com/artifact/com.chrisjenx.yakcov/library) for
+all targets (Android, JVM, JS, Wasm, iOS) — depend on the common artifact and each of your targets
+resolves its own:
 
 ```kotlin
 commonMain {
@@ -84,7 +82,7 @@ commonMain {
 }
 ```
 
-If you only need a specific target you can include that directly, for example for Android:
+For a single target, depend on it directly — Android, for example:
 
 ```kotlin
 dependencies {
@@ -96,12 +94,7 @@ The `PhoneFormat` rule validates phone-number format with no extra dependencies.
 region-aware `Phone` rule needs the (compileOnly) libphonenumber dependency added to your app —
 see [phone validation](https://chrisjenx.github.io/yakcov/recipes/phone/).
 
-## Build locally
+## Building and testing
 
-- check your system with [KDoctor](https://github.com/Kotlin/kdoctor)
-- install JDK 17 or higher on your machine
-
-## Testing
-
-- You will need Chrome installed for JS based tests to run
-- run tests with `./gradlew :library:allTests`
+JDK 17+ required; check your system with [KDoctor](https://github.com/Kotlin/kdoctor). Run tests with
+`./gradlew :library:allTests` — the JS/WasmJS tests need Chrome installed.

--- a/docs-examples/src/commonMain/kotlin/com/chrisjenx/yakcov/docs/mvi/MviExample.kt
+++ b/docs-examples/src/commonMain/kotlin/com/chrisjenx/yakcov/docs/mvi/MviExample.kt
@@ -15,12 +15,12 @@ import androidx.compose.ui.Modifier
 import com.chrisjenx.yakcov.FieldValidationState
 import com.chrisjenx.yakcov.ValueValidatorRule
 import com.chrisjenx.yakcov.hasNoErrors
-import com.chrisjenx.yakcov.onFocusLost
 import com.chrisjenx.yakcov.strings.Email
 import com.chrisjenx.yakcov.strings.MinLength
 import com.chrisjenx.yakcov.strings.Required
 import com.chrisjenx.yakcov.supportingText
 import com.chrisjenx.yakcov.toFieldState
+import com.chrisjenx.yakcov.validationBehavior
 
 // --8<-- [start:mvi-model]
 // Plain top-level rule lists: shared by reduce() and any unit test, no Compose needed.
@@ -35,6 +35,9 @@ data class SignUpModel(
     val passwordState: FieldValidationState = FieldValidationState.Pristine,
     /** null = not attempted, true = accepted, false = blocked (errors surfaced). */
     val submitted: Boolean? = null,
+    /** Monotonic submit counter — drives shake. A repeated invalid submit yields an
+     *  EQUAL FieldValidationState, so a state diff alone can never re-fire the shake. */
+    val submitAttempts: Int = 0,
 ) {
     /** Driven purely by severity (ignores showError) — live from the first frame. */
     val canSubmit: Boolean get() = listOf(emailState, passwordState).hasNoErrors()
@@ -80,6 +83,7 @@ fun reduce(model: SignUpModel, event: SignUpEvent): SignUpModel = when (event) {
         val surfaced = model.copy(
             emailState = emailRules.toFieldState(model.email, showError = true),
             passwordState = passwordRules.toFieldState(model.password, showError = true),
+            submitAttempts = model.submitAttempts + 1,
         )
         surfaced.copy(submitted = surfaced.canSubmit)
     }
@@ -114,7 +118,11 @@ fun MviSignUpScreen(store: SignUpStore = remember { SignUpStore() }) {
             singleLine = true,
             modifier = Modifier
                 .fillMaxWidth()
-                .onFocusLost { store.dispatch(SignUpEvent.EmailFocusLost) },
+                .validationBehavior(
+                    isError = model.emailState.isError,
+                    shakeTrigger = model.submitAttempts,
+                    onFocusLost = { store.dispatch(SignUpEvent.EmailFocusLost) },
+                ),
         )
         OutlinedTextField(
             value = model.password,
@@ -125,7 +133,11 @@ fun MviSignUpScreen(store: SignUpStore = remember { SignUpStore() }) {
             singleLine = true,
             modifier = Modifier
                 .fillMaxWidth()
-                .onFocusLost { store.dispatch(SignUpEvent.PasswordFocusLost) },
+                .validationBehavior(
+                    isError = model.passwordState.isError,
+                    shakeTrigger = model.submitAttempts,
+                    onFocusLost = { store.dispatch(SignUpEvent.PasswordFocusLost) },
+                ),
         )
         Button(
             onClick = { store.dispatch(SignUpEvent.Submit) },

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -60,12 +60,12 @@ modifier = Modifier.validationConfig(
 )
 ```
 
-For headless `FieldValidator`s there's no `validationConfig` modifier; call
-`field.onFocusLost()` from `Modifier.onFocusLost { ... }` to validate-on-focus-lost,
-state-holder owned. For shake, pass `FieldValidator.attempts` as the `shakeTrigger` to
+For headless `FieldValidator`s there is no `validationConfig` modifier. Validate on
+focus loss by calling `field.onFocusLost()` from `Modifier.onFocusLost { ... }`. For
+shake, pass `FieldValidator.attempts` as the `shakeTrigger` of
 `Modifier.validationBehavior(isError, shakeTrigger, onFocusLost)`, or use
-`Modifier.shakeOnInvalid(isError, trigger)` directly — and gate error display via the
-`showError` flag you thread through `toFieldState`.
+`Modifier.shakeOnInvalid(isError, trigger)` directly. Error display stays yours to gate,
+via the `showError` flag you thread through `toFieldState`.
 
 ## Form-level submit
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -62,10 +62,10 @@ modifier = Modifier.validationConfig(
 
 For headless `FieldValidator`s there's no `validationConfig` modifier; call
 `field.onFocusLost()` from `Modifier.onFocusLost { ... }` to validate-on-focus-lost,
-state-holder owned. The `shakeOnInvalid` / `showErrorOnInteraction` knobs are specific to
-the in-composition validators — on the headless path, drive shake yourself (see
-[MVI](patterns/mvi.md)) and gate error display via the `showError` flag you thread
-through `toFieldState`.
+state-holder owned. For shake, pass `FieldValidator.attempts` as the `shakeTrigger` to
+`Modifier.validationBehavior(isError, shakeTrigger, onFocusLost)`, or use
+`Modifier.shakeOnInvalid(isError, trigger)` directly — and gate error display via the
+`showError` flag you thread through `toFieldState`.
 
 ## Form-level submit
 

--- a/docs/patterns/mvi.md
+++ b/docs/patterns/mvi.md
@@ -44,8 +44,22 @@ Notes on the wiring:
 - Cross-field rules (confirm-password, etc.) are SAM lambdas closing over the model —
   see [custom rules](../recipes/custom-rules.md). The built-in `PasswordMatches` couples
   to a *mutable* validator and does **not** fit a reducer.
-- **Shake stays UI-owned:** keep a `rememberShakingState()` in the screen and call
-  `shakingState.shake()` when an invalid submit reduces `submitted` to `false`.
+- **Shake is driven by a monotonic counter, not a state diff.** `FieldValidationState` equality
+  includes its message, so a *second* invalid submit produces an `==` state — no recomposition, and a
+  diff-driven shake would fire once and never again. Thread a `submitAttempts` counter in the model
+  and pass it as `shakeTrigger`; `Modifier.validationBehavior(isError, shakeTrigger, onFocusLost)`
+  bundles that with focus-loss handling. `Modifier.shakeOnInvalid(isError, trigger)` is the
+  standalone form.
+- **Screen readers get no signal from shake.** It is a purely visual `graphicsLayer` translation, and
+  a repeat invalid submit changes nothing in the semantics tree. If the form must be accessible,
+  announce the failure yourself on submit.
+- **Give disposable fields a stable `key`.** The "don't shake on first frame" guard remembers the
+  trigger it was born with, so a field re-created after its subtree was disposed — a `LazyColumn` item
+  without a stable `key`, a nav destination re-entered — adopts the current counter as its new
+  baseline and swallows any shake that became due while it was gone.
+- **`onFocusCursorToEnd` needs a `TextFieldValue` in your model,** not a `String`. The examples on
+  this page hoist `String`, so adopting cursor-to-end means migrating the field's model type.
+  `TextFieldValue` is a value type and is safe inside an immutable model.
 
 ## Persistence & process death
 

--- a/library/api/android/library.api
+++ b/library/api/android/library.api
@@ -1,0 +1,706 @@
+public final class com/chrisjenx/yakcov/FieldValidationState {
+	public static final field $stable I
+	public static final field Companion Lcom/chrisjenx/yakcov/FieldValidationState$Companion;
+	public fun <init> ()V
+	public fun <init> (Lcom/chrisjenx/yakcov/ValidationResult$Outcome;ZLcom/chrisjenx/yakcov/ValidationResult;)V
+	public synthetic fun <init> (Lcom/chrisjenx/yakcov/ValidationResult$Outcome;ZLcom/chrisjenx/yakcov/ValidationResult;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lcom/chrisjenx/yakcov/ValidationResult$Outcome;
+	public final fun component2 ()Z
+	public final fun component3 ()Lcom/chrisjenx/yakcov/ValidationResult;
+	public final fun copy (Lcom/chrisjenx/yakcov/ValidationResult$Outcome;ZLcom/chrisjenx/yakcov/ValidationResult;)Lcom/chrisjenx/yakcov/FieldValidationState;
+	public static synthetic fun copy$default (Lcom/chrisjenx/yakcov/FieldValidationState;Lcom/chrisjenx/yakcov/ValidationResult$Outcome;ZLcom/chrisjenx/yakcov/ValidationResult;ILjava/lang/Object;)Lcom/chrisjenx/yakcov/FieldValidationState;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getResult ()Lcom/chrisjenx/yakcov/ValidationResult;
+	public final fun getSeverity ()Lcom/chrisjenx/yakcov/ValidationResult$Outcome;
+	public final fun getShowError ()Z
+	public fun hashCode ()I
+	public final fun isError ()Z
+	public final fun isWarning ()Z
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class com/chrisjenx/yakcov/FieldValidationState$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field $stable I
+	public static final field INSTANCE Lcom/chrisjenx/yakcov/FieldValidationState$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/chrisjenx/yakcov/FieldValidationState;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/chrisjenx/yakcov/FieldValidationState;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/chrisjenx/yakcov/FieldValidationState$Companion {
+	public final fun getPristine ()Lcom/chrisjenx/yakcov/FieldValidationState;
+	public final fun getSaver ()Landroidx/compose/runtime/saveable/Saver;
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/chrisjenx/yakcov/FieldValidationStateKt {
+	public static final fun hasNoErrors (Ljava/util/List;)Z
+	public static final fun supportingText (Lcom/chrisjenx/yakcov/FieldValidationState;Ljava/lang/String;Landroidx/compose/runtime/Composer;II)Lkotlin/jvm/functions/Function2;
+	public static final fun text (Lcom/chrisjenx/yakcov/FieldValidationState;Ljava/lang/String;Landroidx/compose/runtime/Composer;II)Ljava/lang/String;
+	public static final fun toFieldState (Lcom/chrisjenx/yakcov/ValueValidatorRule;Ljava/lang/Object;Z)Lcom/chrisjenx/yakcov/FieldValidationState;
+	public static final fun toFieldState (Ljava/util/List;Ljava/lang/Object;Z)Lcom/chrisjenx/yakcov/FieldValidationState;
+}
+
+public final class com/chrisjenx/yakcov/FieldValidator {
+	public static final field $stable I
+	public fun <init> (Ljava/lang/Object;Ljava/util/List;ZLcom/chrisjenx/yakcov/FieldValidatorObserver;)V
+	public synthetic fun <init> (Ljava/lang/Object;Ljava/util/List;ZLcom/chrisjenx/yakcov/FieldValidatorObserver;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getAttempts ()I
+	public final fun getState ()Lcom/chrisjenx/yakcov/FieldValidationState;
+	public final fun getValue ()Ljava/lang/Object;
+	public final fun onFocusLost ()Z
+	public final fun onValueChange (Ljava/lang/Object;)V
+	public final fun reset ()V
+	public final fun reset (Ljava/lang/Object;)V
+	public final fun validate ()Z
+}
+
+public abstract interface class com/chrisjenx/yakcov/FieldValidatorEvent {
+	public abstract fun getState ()Lcom/chrisjenx/yakcov/FieldValidationState;
+	public abstract fun getValue ()Ljava/lang/Object;
+}
+
+public final class com/chrisjenx/yakcov/FieldValidatorEvent$Reset : com/chrisjenx/yakcov/FieldValidatorEvent {
+	public static final field $stable I
+	public fun <init> (Ljava/lang/Object;Lcom/chrisjenx/yakcov/FieldValidationState;)V
+	public final fun component1 ()Ljava/lang/Object;
+	public final fun component2 ()Lcom/chrisjenx/yakcov/FieldValidationState;
+	public final fun copy (Ljava/lang/Object;Lcom/chrisjenx/yakcov/FieldValidationState;)Lcom/chrisjenx/yakcov/FieldValidatorEvent$Reset;
+	public static synthetic fun copy$default (Lcom/chrisjenx/yakcov/FieldValidatorEvent$Reset;Ljava/lang/Object;Lcom/chrisjenx/yakcov/FieldValidationState;ILjava/lang/Object;)Lcom/chrisjenx/yakcov/FieldValidatorEvent$Reset;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getState ()Lcom/chrisjenx/yakcov/FieldValidationState;
+	public fun getValue ()Ljava/lang/Object;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/chrisjenx/yakcov/FieldValidatorEvent$Validated : com/chrisjenx/yakcov/FieldValidatorEvent {
+	public static final field $stable I
+	public fun <init> (Ljava/lang/Object;Lcom/chrisjenx/yakcov/FieldValidationState;)V
+	public final fun component1 ()Ljava/lang/Object;
+	public final fun component2 ()Lcom/chrisjenx/yakcov/FieldValidationState;
+	public final fun copy (Ljava/lang/Object;Lcom/chrisjenx/yakcov/FieldValidationState;)Lcom/chrisjenx/yakcov/FieldValidatorEvent$Validated;
+	public static synthetic fun copy$default (Lcom/chrisjenx/yakcov/FieldValidatorEvent$Validated;Ljava/lang/Object;Lcom/chrisjenx/yakcov/FieldValidationState;ILjava/lang/Object;)Lcom/chrisjenx/yakcov/FieldValidatorEvent$Validated;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getState ()Lcom/chrisjenx/yakcov/FieldValidationState;
+	public fun getValue ()Ljava/lang/Object;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/chrisjenx/yakcov/FieldValidatorEvent$ValueChanged : com/chrisjenx/yakcov/FieldValidatorEvent {
+	public static final field $stable I
+	public fun <init> (Ljava/lang/Object;Lcom/chrisjenx/yakcov/FieldValidationState;)V
+	public final fun component1 ()Ljava/lang/Object;
+	public final fun component2 ()Lcom/chrisjenx/yakcov/FieldValidationState;
+	public final fun copy (Ljava/lang/Object;Lcom/chrisjenx/yakcov/FieldValidationState;)Lcom/chrisjenx/yakcov/FieldValidatorEvent$ValueChanged;
+	public static synthetic fun copy$default (Lcom/chrisjenx/yakcov/FieldValidatorEvent$ValueChanged;Ljava/lang/Object;Lcom/chrisjenx/yakcov/FieldValidationState;ILjava/lang/Object;)Lcom/chrisjenx/yakcov/FieldValidatorEvent$ValueChanged;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getState ()Lcom/chrisjenx/yakcov/FieldValidationState;
+	public fun getValue ()Ljava/lang/Object;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/chrisjenx/yakcov/FieldValidatorKt {
+	public static final fun validate (Ljava/util/List;)Z
+}
+
+public abstract interface class com/chrisjenx/yakcov/FieldValidatorObserver {
+	public abstract fun onEvent (Lcom/chrisjenx/yakcov/FieldValidatorEvent;)V
+}
+
+public final class com/chrisjenx/yakcov/ModifiersKt {
+	public static final fun onFocusCursorToEnd (Landroidx/compose/ui/Modifier;Landroidx/compose/ui/text/input/TextFieldValue;Lkotlin/jvm/functions/Function1;Lkotlinx/coroutines/CoroutineScope;ZLandroidx/compose/runtime/Composer;II)Landroidx/compose/ui/Modifier;
+	public static final fun onFocusLost (Landroidx/compose/ui/Modifier;Lkotlin/jvm/functions/Function0;)Landroidx/compose/ui/Modifier;
+	public static final fun shakeOnInvalid (Landroidx/compose/ui/Modifier;ZI)Landroidx/compose/ui/Modifier;
+	public static final fun validationBehavior (Landroidx/compose/ui/Modifier;ZLjava/lang/Integer;Lkotlin/jvm/functions/Function0;)Landroidx/compose/ui/Modifier;
+	public static synthetic fun validationBehavior$default (Landroidx/compose/ui/Modifier;ZLjava/lang/Integer;Lkotlin/jvm/functions/Function0;ILjava/lang/Object;)Landroidx/compose/ui/Modifier;
+	public static final fun validationConfig (Landroidx/compose/ui/Modifier;Lcom/chrisjenx/yakcov/ValueValidator;ZZZ)Landroidx/compose/ui/Modifier;
+	public static synthetic fun validationConfig$default (Landroidx/compose/ui/Modifier;Lcom/chrisjenx/yakcov/ValueValidator;ZZZILjava/lang/Object;)Landroidx/compose/ui/Modifier;
+}
+
+public final class com/chrisjenx/yakcov/Optional : com/chrisjenx/yakcov/ValueValidatorRule {
+	public static final field $stable I
+	public fun <init> (Landroidx/compose/runtime/State;Lcom/chrisjenx/yakcov/ValueValidatorRule;)V
+	public fun <init> (ZLcom/chrisjenx/yakcov/ValueValidatorRule;)V
+	public fun validate (Ljava/lang/Object;)Lcom/chrisjenx/yakcov/ValidationResult;
+}
+
+public final class com/chrisjenx/yakcov/PhoneNumberUtilInitializer : androidx/startup/Initializer {
+	public static final field $stable I
+	public fun <init> ()V
+	public fun create (Landroid/content/Context;)Landroid/content/Context;
+	public synthetic fun create (Landroid/content/Context;)Ljava/lang/Object;
+	public fun dependencies ()Ljava/util/List;
+}
+
+public final class com/chrisjenx/yakcov/PhoneNumberUtilTestSupportKt {
+	public static final fun initPhoneNumberUtilForTest ()V
+	public static final fun initPhoneNumberUtilForTest (Lio/michaelrocks/libphonenumber/kotlin/PhoneNumberUtil;)V
+	public static final fun resetPhoneNumberUtilForTest ()V
+}
+
+public final class com/chrisjenx/yakcov/RegexExtKt {
+	public static final fun isEmail (Ljava/lang/String;)Z
+	public static final fun isPhoneNumber (Ljava/lang/String;Ljava/lang/String;)Z
+	public static synthetic fun isPhoneNumber$default (Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Z
+	public static final fun isPhoneNumberFormat (Ljava/lang/String;)Z
+}
+
+public final class com/chrisjenx/yakcov/RegularValidationResult : com/chrisjenx/yakcov/ValidationResult {
+	public static final field $stable I
+	public static final field Companion Lcom/chrisjenx/yakcov/RegularValidationResult$Companion;
+	public synthetic fun <init> (Ljava/lang/String;Lcom/chrisjenx/yakcov/ValidationResult$Outcome;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun copy (Ljava/lang/String;Lcom/chrisjenx/yakcov/ValidationResult$Outcome;)Lcom/chrisjenx/yakcov/RegularValidationResult;
+	public static synthetic fun copy$default (Lcom/chrisjenx/yakcov/RegularValidationResult;Ljava/lang/String;Lcom/chrisjenx/yakcov/ValidationResult$Outcome;ILjava/lang/Object;)Lcom/chrisjenx/yakcov/RegularValidationResult;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun format (Landroidx/compose/runtime/Composer;I)Ljava/lang/String;
+	public fun hashCode ()I
+	public fun messageOrNull ()Ljava/lang/String;
+	public fun outcome ()Lcom/chrisjenx/yakcov/ValidationResult$Outcome;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/chrisjenx/yakcov/RegularValidationResult$Companion {
+	public final fun error (Ljava/lang/String;)Lcom/chrisjenx/yakcov/RegularValidationResult;
+	public final fun info (Ljava/lang/String;)Lcom/chrisjenx/yakcov/RegularValidationResult;
+	public final fun success (Ljava/lang/String;)Lcom/chrisjenx/yakcov/RegularValidationResult;
+	public static synthetic fun success$default (Lcom/chrisjenx/yakcov/RegularValidationResult$Companion;Ljava/lang/String;ILjava/lang/Object;)Lcom/chrisjenx/yakcov/RegularValidationResult;
+	public final fun warning (Ljava/lang/String;)Lcom/chrisjenx/yakcov/RegularValidationResult;
+}
+
+public final class com/chrisjenx/yakcov/ResourceValidationResult : com/chrisjenx/yakcov/ValidationResult {
+	public static final field $stable I
+	public static final field Companion Lcom/chrisjenx/yakcov/ResourceValidationResult$Companion;
+	public synthetic fun <init> (Lorg/jetbrains/compose/resources/StringResource;Lcom/chrisjenx/yakcov/ValidationResult$Outcome;[Ljava/lang/Object;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun copy (Lorg/jetbrains/compose/resources/StringResource;Ljava/util/List;Lcom/chrisjenx/yakcov/ValidationResult$Outcome;)Lcom/chrisjenx/yakcov/ResourceValidationResult;
+	public static synthetic fun copy$default (Lcom/chrisjenx/yakcov/ResourceValidationResult;Lorg/jetbrains/compose/resources/StringResource;Ljava/util/List;Lcom/chrisjenx/yakcov/ValidationResult$Outcome;ILjava/lang/Object;)Lcom/chrisjenx/yakcov/ResourceValidationResult;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun format (Landroidx/compose/runtime/Composer;I)Ljava/lang/String;
+	public fun hashCode ()I
+	public fun messageOrNull ()Ljava/lang/String;
+	public fun outcome ()Lcom/chrisjenx/yakcov/ValidationResult$Outcome;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/chrisjenx/yakcov/ResourceValidationResult$Companion {
+	public final fun error (Lorg/jetbrains/compose/resources/StringResource;[Ljava/lang/Object;)Lcom/chrisjenx/yakcov/ResourceValidationResult;
+	public final fun info (Lorg/jetbrains/compose/resources/StringResource;[Ljava/lang/Object;)Lcom/chrisjenx/yakcov/ResourceValidationResult;
+	public final fun success (Lorg/jetbrains/compose/resources/StringResource;[Ljava/lang/Object;)Lcom/chrisjenx/yakcov/ResourceValidationResult;
+	public static synthetic fun success$default (Lcom/chrisjenx/yakcov/ResourceValidationResult$Companion;Lorg/jetbrains/compose/resources/StringResource;[Ljava/lang/Object;ILjava/lang/Object;)Lcom/chrisjenx/yakcov/ResourceValidationResult;
+	public final fun warning (Lorg/jetbrains/compose/resources/StringResource;[Ljava/lang/Object;)Lcom/chrisjenx/yakcov/ResourceValidationResult;
+}
+
+public final class com/chrisjenx/yakcov/RuleCombinatorsKt {
+	public static final fun onlyWhen (Lcom/chrisjenx/yakcov/ValueValidatorRule;Landroidx/compose/runtime/State;)Lcom/chrisjenx/yakcov/ValueValidatorRule;
+	public static final fun onlyWhen (Lcom/chrisjenx/yakcov/ValueValidatorRule;Z)Lcom/chrisjenx/yakcov/ValueValidatorRule;
+}
+
+public final class com/chrisjenx/yakcov/ShakingState {
+	public static final field $stable I
+	public fun <init> (Lcom/chrisjenx/yakcov/ShakingState$Strength;Lcom/chrisjenx/yakcov/ShakingState$Direction;)V
+	public final fun getXPosition ()Landroidx/compose/animation/core/Animatable;
+	public final fun shake (ILkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun shake$default (Lcom/chrisjenx/yakcov/ShakingState;ILkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+}
+
+public final class com/chrisjenx/yakcov/ShakingState$Direction : java/lang/Enum {
+	public static final field LEFT Lcom/chrisjenx/yakcov/ShakingState$Direction;
+	public static final field LEFT_THEN_RIGHT Lcom/chrisjenx/yakcov/ShakingState$Direction;
+	public static final field RIGHT Lcom/chrisjenx/yakcov/ShakingState$Direction;
+	public static final field RIGHT_THEN_LEFT Lcom/chrisjenx/yakcov/ShakingState$Direction;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lcom/chrisjenx/yakcov/ShakingState$Direction;
+	public static fun values ()[Lcom/chrisjenx/yakcov/ShakingState$Direction;
+}
+
+public abstract class com/chrisjenx/yakcov/ShakingState$Strength {
+	public static final field $stable I
+	public synthetic fun <init> (FLkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getValue ()F
+}
+
+public final class com/chrisjenx/yakcov/ShakingState$Strength$Custom : com/chrisjenx/yakcov/ShakingState$Strength {
+	public static final field $stable I
+	public fun <init> (F)V
+	public final fun component1 ()F
+	public final fun copy (F)Lcom/chrisjenx/yakcov/ShakingState$Strength$Custom;
+	public static synthetic fun copy$default (Lcom/chrisjenx/yakcov/ShakingState$Strength$Custom;FILjava/lang/Object;)Lcom/chrisjenx/yakcov/ShakingState$Strength$Custom;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getStrength ()F
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/chrisjenx/yakcov/ShakingState$Strength$Normal : com/chrisjenx/yakcov/ShakingState$Strength {
+	public static final field $stable I
+	public static final field INSTANCE Lcom/chrisjenx/yakcov/ShakingState$Strength$Normal;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/chrisjenx/yakcov/ShakingState$Strength$Strong : com/chrisjenx/yakcov/ShakingState$Strength {
+	public static final field $stable I
+	public static final field INSTANCE Lcom/chrisjenx/yakcov/ShakingState$Strength$Strong;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/chrisjenx/yakcov/ShakingStateKt {
+	public static final fun rememberShakingState (Lcom/chrisjenx/yakcov/ShakingState$Strength;Lcom/chrisjenx/yakcov/ShakingState$Direction;Landroidx/compose/runtime/Composer;II)Lcom/chrisjenx/yakcov/ShakingState;
+	public static final fun shakable (Landroidx/compose/ui/Modifier;Lcom/chrisjenx/yakcov/ShakingState;)Landroidx/compose/ui/Modifier;
+}
+
+public abstract interface class com/chrisjenx/yakcov/ValidationResult {
+	public abstract fun format (Landroidx/compose/runtime/Composer;I)Ljava/lang/String;
+	public fun messageOrNull ()Ljava/lang/String;
+	public fun outcome ()Lcom/chrisjenx/yakcov/ValidationResult$Outcome;
+}
+
+public final class com/chrisjenx/yakcov/ValidationResult$DefaultImpls {
+	public static fun messageOrNull (Lcom/chrisjenx/yakcov/ValidationResult;)Ljava/lang/String;
+	public static fun outcome (Lcom/chrisjenx/yakcov/ValidationResult;)Lcom/chrisjenx/yakcov/ValidationResult$Outcome;
+}
+
+public final class com/chrisjenx/yakcov/ValidationResult$Outcome : java/lang/Enum {
+	public static final field Companion Lcom/chrisjenx/yakcov/ValidationResult$Outcome$Companion;
+	public static final field ERROR Lcom/chrisjenx/yakcov/ValidationResult$Outcome;
+	public static final field INFO Lcom/chrisjenx/yakcov/ValidationResult$Outcome;
+	public static final field SUCCESS Lcom/chrisjenx/yakcov/ValidationResult$Outcome;
+	public static final field WARNING Lcom/chrisjenx/yakcov/ValidationResult$Outcome;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public final fun getSeverity ()S
+	public static fun valueOf (Ljava/lang/String;)Lcom/chrisjenx/yakcov/ValidationResult$Outcome;
+	public static fun values ()[Lcom/chrisjenx/yakcov/ValidationResult$Outcome;
+}
+
+public final class com/chrisjenx/yakcov/ValidationResult$Outcome$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public abstract class com/chrisjenx/yakcov/ValueValidator {
+	public static final field $stable I
+	public static final field Companion Lcom/chrisjenx/yakcov/ValueValidator$Companion;
+	public fun <init> (Landroidx/compose/runtime/MutableState;Ljava/util/List;ZZLjava/lang/String;Lkotlin/jvm/functions/Function2;)V
+	public synthetic fun <init> (Landroidx/compose/runtime/MutableState;Ljava/util/List;ZZLjava/lang/String;Lkotlin/jvm/functions/Function2;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun equals (Ljava/lang/Object;)Z
+	protected final fun getAlwaysShowRule ()Z
+	public final fun getErrorString (Landroidx/compose/runtime/Composer;I)Ljava/lang/String;
+	protected final fun getRules ()Ljava/util/List;
+	protected final fun getState ()Landroidx/compose/runtime/MutableState;
+	public final fun getValidationResultString (SLandroidx/compose/runtime/Composer;II)Ljava/lang/String;
+	public final fun getValidationResults ()Ljava/util/List;
+	protected final fun getValidationSeparator ()Ljava/lang/String;
+	public final fun getValue ()Ljava/lang/Object;
+	public fun hashCode ()I
+	public final fun isError ()Z
+	public final fun isValid ()Z
+	public fun onValueChange (Ljava/lang/Object;)V
+	public final fun outcome ()Lcom/chrisjenx/yakcov/ValidationResult$Outcome;
+	public fun reset ()V
+	public final fun setValue (Ljava/lang/Object;)V
+	public final fun shakeOnInvalid (Landroidx/compose/ui/Modifier;)Landroidx/compose/ui/Modifier;
+	public final fun supportingText (SLjava/lang/String;Landroidx/compose/runtime/Composer;II)Lkotlin/jvm/functions/Function2;
+	public fun toString ()Ljava/lang/String;
+	public fun validate (Ljava/lang/Object;)Z
+	public static synthetic fun validate$default (Lcom/chrisjenx/yakcov/ValueValidator;Ljava/lang/Object;ILjava/lang/Object;)Z
+	public final fun validateFocusChanged (Landroidx/compose/ui/Modifier;)Landroidx/compose/ui/Modifier;
+	public fun validateWithResult (Ljava/lang/Object;)Lcom/chrisjenx/yakcov/ValidationResult$Outcome;
+	public static synthetic fun validateWithResult$default (Lcom/chrisjenx/yakcov/ValueValidator;Ljava/lang/Object;ILjava/lang/Object;)Lcom/chrisjenx/yakcov/ValidationResult$Outcome;
+	public final fun validationConfig (Landroidx/compose/ui/Modifier;ZZZ)Landroidx/compose/ui/Modifier;
+	public static synthetic fun validationConfig$default (Lcom/chrisjenx/yakcov/ValueValidator;Landroidx/compose/ui/Modifier;ZZZILjava/lang/Object;)Landroidx/compose/ui/Modifier;
+}
+
+public final class com/chrisjenx/yakcov/ValueValidator$Companion {
+	public final fun getDefaultValidationSeparator ()Ljava/lang/String;
+	public final fun setDefaultValidationSeparator (Ljava/lang/String;)V
+}
+
+public final class com/chrisjenx/yakcov/ValueValidatorKt {
+	public static final fun validate (Ljava/util/List;)Z
+	public static final fun validateWithResult (Ljava/util/List;)Lcom/chrisjenx/yakcov/ValidationResult$Outcome;
+}
+
+public abstract interface class com/chrisjenx/yakcov/ValueValidatorRule {
+	public abstract fun validate (Ljava/lang/Object;)Lcom/chrisjenx/yakcov/ValidationResult;
+}
+
+public final class com/chrisjenx/yakcov/generic/GenericValueValidator : com/chrisjenx/yakcov/ValueValidator {
+	public static final field $stable I
+	public fun <init> (Landroidx/compose/runtime/MutableState;Ljava/util/List;ZZLjava/lang/String;)V
+	public synthetic fun <init> (Landroidx/compose/runtime/MutableState;Ljava/util/List;ZZLjava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+}
+
+public final class com/chrisjenx/yakcov/generic/GenericValueValidatorKt {
+	public static final fun rememberGenericValueValidator (Ljava/lang/Object;Ljava/util/List;ZZLjava/lang/String;Landroidx/compose/runtime/Composer;II)Lcom/chrisjenx/yakcov/generic/GenericValueValidator;
+}
+
+public final class com/chrisjenx/yakcov/generic/InList : com/chrisjenx/yakcov/ValueValidatorRule {
+	public static final field $stable I
+	public fun <init> (Landroidx/compose/runtime/State;)V
+	public fun <init> (Ljava/util/List;)V
+	public fun validate (Ljava/lang/Object;)Lcom/chrisjenx/yakcov/ValidationResult;
+}
+
+public final class com/chrisjenx/yakcov/generic/InRange : com/chrisjenx/yakcov/ValueValidatorRule {
+	public static final field $stable I
+	public fun <init> (Landroidx/compose/runtime/State;Landroidx/compose/runtime/State;)V
+	public fun <init> (Ljava/lang/Number;Ljava/lang/Number;)V
+	public fun validate (Ljava/lang/Number;)Lcom/chrisjenx/yakcov/ValidationResult;
+	public synthetic fun validate (Ljava/lang/Object;)Lcom/chrisjenx/yakcov/ValidationResult;
+}
+
+public final class com/chrisjenx/yakcov/generic/IsChecked : com/chrisjenx/yakcov/ValueValidatorRule {
+	public static final field $stable I
+	public static final field INSTANCE Lcom/chrisjenx/yakcov/generic/IsChecked;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public fun validate (Ljava/lang/Boolean;)Lcom/chrisjenx/yakcov/ValidationResult;
+	public synthetic fun validate (Ljava/lang/Object;)Lcom/chrisjenx/yakcov/ValidationResult;
+}
+
+public final class com/chrisjenx/yakcov/generic/IsNotChecked : com/chrisjenx/yakcov/ValueValidatorRule {
+	public static final field $stable I
+	public static final field INSTANCE Lcom/chrisjenx/yakcov/generic/IsNotChecked;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public fun validate (Ljava/lang/Boolean;)Lcom/chrisjenx/yakcov/ValidationResult;
+	public synthetic fun validate (Ljava/lang/Object;)Lcom/chrisjenx/yakcov/ValidationResult;
+}
+
+public final class com/chrisjenx/yakcov/generic/ListNotEmpty : com/chrisjenx/yakcov/ValueValidatorRule {
+	public static final field $stable I
+	public fun <init> ()V
+	public synthetic fun validate (Ljava/lang/Object;)Lcom/chrisjenx/yakcov/ValidationResult;
+	public fun validate (Ljava/util/List;)Lcom/chrisjenx/yakcov/ValidationResult;
+}
+
+public final class com/chrisjenx/yakcov/generic/Max : com/chrisjenx/yakcov/ValueValidatorRule {
+	public static final field $stable I
+	public fun <init> (Landroidx/compose/runtime/State;)V
+	public fun <init> (Ljava/lang/Number;)V
+	public fun validate (Ljava/lang/Number;)Lcom/chrisjenx/yakcov/ValidationResult;
+	public synthetic fun validate (Ljava/lang/Object;)Lcom/chrisjenx/yakcov/ValidationResult;
+}
+
+public final class com/chrisjenx/yakcov/generic/Min : com/chrisjenx/yakcov/ValueValidatorRule {
+	public static final field $stable I
+	public fun <init> (Landroidx/compose/runtime/State;)V
+	public fun <init> (Ljava/lang/Number;)V
+	public fun validate (Ljava/lang/Number;)Lcom/chrisjenx/yakcov/ValidationResult;
+	public synthetic fun validate (Ljava/lang/Object;)Lcom/chrisjenx/yakcov/ValidationResult;
+}
+
+public final class com/chrisjenx/yakcov/generic/Required : com/chrisjenx/yakcov/ValueValidatorRule {
+	public static final field $stable I
+	public fun <init> ()V
+	public fun validate (Ljava/lang/Object;)Lcom/chrisjenx/yakcov/ValidationResult;
+}
+
+public final class com/chrisjenx/yakcov/strings/DayValidation : com/chrisjenx/yakcov/ValueValidatorRule {
+	public static final field $stable I
+	public fun <init> (Landroidx/compose/runtime/State;)V
+	public fun <init> (Lkotlinx/datetime/LocalDate;)V
+	public final fun component1 ()Landroidx/compose/runtime/State;
+	public final fun copy (Landroidx/compose/runtime/State;)Lcom/chrisjenx/yakcov/strings/DayValidation;
+	public static synthetic fun copy$default (Lcom/chrisjenx/yakcov/strings/DayValidation;Landroidx/compose/runtime/State;ILjava/lang/Object;)Lcom/chrisjenx/yakcov/strings/DayValidation;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getLocalDate ()Landroidx/compose/runtime/State;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public synthetic fun validate (Ljava/lang/Object;)Lcom/chrisjenx/yakcov/ValidationResult;
+	public fun validate (Ljava/lang/String;)Lcom/chrisjenx/yakcov/ValidationResult;
+}
+
+public final class com/chrisjenx/yakcov/strings/Decimal : com/chrisjenx/yakcov/ValueValidatorRule {
+	public static final field $stable I
+	public static final field INSTANCE Lcom/chrisjenx/yakcov/strings/Decimal;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public synthetic fun validate (Ljava/lang/Object;)Lcom/chrisjenx/yakcov/ValidationResult;
+	public fun validate (Ljava/lang/String;)Lcom/chrisjenx/yakcov/ValidationResult;
+}
+
+public final class com/chrisjenx/yakcov/strings/Email : com/chrisjenx/yakcov/ValueValidatorRule {
+	public static final field $stable I
+	public static final field INSTANCE Lcom/chrisjenx/yakcov/strings/Email;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public synthetic fun validate (Ljava/lang/Object;)Lcom/chrisjenx/yakcov/ValidationResult;
+	public fun validate (Ljava/lang/String;)Lcom/chrisjenx/yakcov/ValidationResult;
+}
+
+public final class com/chrisjenx/yakcov/strings/HexColor : com/chrisjenx/yakcov/ValueValidatorRule {
+	public static final field $stable I
+	public static final field INSTANCE Lcom/chrisjenx/yakcov/strings/HexColor;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public synthetic fun validate (Ljava/lang/Object;)Lcom/chrisjenx/yakcov/ValidationResult;
+	public fun validate (Ljava/lang/String;)Lcom/chrisjenx/yakcov/ValidationResult;
+}
+
+public final class com/chrisjenx/yakcov/strings/MaxLength : com/chrisjenx/yakcov/ValueValidatorRule {
+	public static final field $stable I
+	public fun <init> (I)V
+	public fun <init> (Landroidx/compose/runtime/State;)V
+	public final fun component1 ()Landroidx/compose/runtime/State;
+	public final fun copy (Landroidx/compose/runtime/State;)Lcom/chrisjenx/yakcov/strings/MaxLength;
+	public static synthetic fun copy$default (Lcom/chrisjenx/yakcov/strings/MaxLength;Landroidx/compose/runtime/State;ILjava/lang/Object;)Lcom/chrisjenx/yakcov/strings/MaxLength;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getMaxLength ()Landroidx/compose/runtime/State;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public synthetic fun validate (Ljava/lang/Object;)Lcom/chrisjenx/yakcov/ValidationResult;
+	public fun validate (Ljava/lang/String;)Lcom/chrisjenx/yakcov/ValidationResult;
+}
+
+public final class com/chrisjenx/yakcov/strings/MaxValue : com/chrisjenx/yakcov/ValueValidatorRule {
+	public static final field $stable I
+	public fun <init> (Landroidx/compose/runtime/State;)V
+	public fun <init> (Ljava/lang/Number;)V
+	public final fun component1 ()Landroidx/compose/runtime/State;
+	public final fun copy (Landroidx/compose/runtime/State;)Lcom/chrisjenx/yakcov/strings/MaxValue;
+	public static synthetic fun copy$default (Lcom/chrisjenx/yakcov/strings/MaxValue;Landroidx/compose/runtime/State;ILjava/lang/Object;)Lcom/chrisjenx/yakcov/strings/MaxValue;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getMaxValue ()Landroidx/compose/runtime/State;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public synthetic fun validate (Ljava/lang/Object;)Lcom/chrisjenx/yakcov/ValidationResult;
+	public fun validate (Ljava/lang/String;)Lcom/chrisjenx/yakcov/ValidationResult;
+}
+
+public final class com/chrisjenx/yakcov/strings/MinLength : com/chrisjenx/yakcov/ValueValidatorRule {
+	public static final field $stable I
+	public fun <init> (IZZ)V
+	public synthetic fun <init> (IZZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Landroidx/compose/runtime/State;Landroidx/compose/runtime/State;Landroidx/compose/runtime/State;)V
+	public synthetic fun <init> (Landroidx/compose/runtime/State;Landroidx/compose/runtime/State;Landroidx/compose/runtime/State;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Landroidx/compose/runtime/State;
+	public final fun component2 ()Landroidx/compose/runtime/State;
+	public final fun component3 ()Landroidx/compose/runtime/State;
+	public final fun copy (Landroidx/compose/runtime/State;Landroidx/compose/runtime/State;Landroidx/compose/runtime/State;)Lcom/chrisjenx/yakcov/strings/MinLength;
+	public static synthetic fun copy$default (Lcom/chrisjenx/yakcov/strings/MinLength;Landroidx/compose/runtime/State;Landroidx/compose/runtime/State;Landroidx/compose/runtime/State;ILjava/lang/Object;)Lcom/chrisjenx/yakcov/strings/MinLength;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getIncludeWhiteSpace ()Landroidx/compose/runtime/State;
+	public final fun getMinLength ()Landroidx/compose/runtime/State;
+	public final fun getTrim ()Landroidx/compose/runtime/State;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public synthetic fun validate (Ljava/lang/Object;)Lcom/chrisjenx/yakcov/ValidationResult;
+	public fun validate (Ljava/lang/String;)Lcom/chrisjenx/yakcov/ValidationResult;
+}
+
+public final class com/chrisjenx/yakcov/strings/MinValue : com/chrisjenx/yakcov/ValueValidatorRule {
+	public static final field $stable I
+	public fun <init> (Landroidx/compose/runtime/State;)V
+	public fun <init> (Ljava/lang/Number;)V
+	public final fun component1 ()Landroidx/compose/runtime/State;
+	public final fun copy (Landroidx/compose/runtime/State;)Lcom/chrisjenx/yakcov/strings/MinValue;
+	public static synthetic fun copy$default (Lcom/chrisjenx/yakcov/strings/MinValue;Landroidx/compose/runtime/State;ILjava/lang/Object;)Lcom/chrisjenx/yakcov/strings/MinValue;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getMinValue ()Landroidx/compose/runtime/State;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public synthetic fun validate (Ljava/lang/Object;)Lcom/chrisjenx/yakcov/ValidationResult;
+	public fun validate (Ljava/lang/String;)Lcom/chrisjenx/yakcov/ValidationResult;
+}
+
+public final class com/chrisjenx/yakcov/strings/MonthValidation : com/chrisjenx/yakcov/ValueValidatorRule {
+	public static final field $stable I
+	public fun <init> (Landroidx/compose/runtime/State;)V
+	public fun <init> (Lkotlinx/datetime/LocalDate;)V
+	public final fun component1 ()Landroidx/compose/runtime/State;
+	public final fun copy (Landroidx/compose/runtime/State;)Lcom/chrisjenx/yakcov/strings/MonthValidation;
+	public static synthetic fun copy$default (Lcom/chrisjenx/yakcov/strings/MonthValidation;Landroidx/compose/runtime/State;ILjava/lang/Object;)Lcom/chrisjenx/yakcov/strings/MonthValidation;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getLocalDate ()Landroidx/compose/runtime/State;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public synthetic fun validate (Ljava/lang/Object;)Lcom/chrisjenx/yakcov/ValidationResult;
+	public fun validate (Ljava/lang/String;)Lcom/chrisjenx/yakcov/ValidationResult;
+}
+
+public final class com/chrisjenx/yakcov/strings/Numeric : com/chrisjenx/yakcov/ValueValidatorRule {
+	public static final field $stable I
+	public static final field INSTANCE Lcom/chrisjenx/yakcov/strings/Numeric;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public synthetic fun validate (Ljava/lang/Object;)Lcom/chrisjenx/yakcov/ValidationResult;
+	public fun validate (Ljava/lang/String;)Lcom/chrisjenx/yakcov/ValidationResult;
+}
+
+public final class com/chrisjenx/yakcov/strings/OneOf : com/chrisjenx/yakcov/ValueValidatorRule {
+	public static final field $stable I
+	public fun <init> (Landroidx/compose/runtime/State;ZZ)V
+	public synthetic fun <init> (Landroidx/compose/runtime/State;ZZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/util/Set;ZZ)V
+	public synthetic fun <init> (Ljava/util/Set;ZZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Landroidx/compose/runtime/State;
+	public final fun component2 ()Z
+	public final fun component3 ()Z
+	public final fun copy (Landroidx/compose/runtime/State;ZZ)Lcom/chrisjenx/yakcov/strings/OneOf;
+	public static synthetic fun copy$default (Lcom/chrisjenx/yakcov/strings/OneOf;Landroidx/compose/runtime/State;ZZILjava/lang/Object;)Lcom/chrisjenx/yakcov/strings/OneOf;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAllowed ()Landroidx/compose/runtime/State;
+	public final fun getIgnoreCase ()Z
+	public final fun getTrim ()Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public synthetic fun validate (Ljava/lang/Object;)Lcom/chrisjenx/yakcov/ValidationResult;
+	public fun validate (Ljava/lang/String;)Lcom/chrisjenx/yakcov/ValidationResult;
+}
+
+public final class com/chrisjenx/yakcov/strings/Phone : com/chrisjenx/yakcov/ValueValidatorRule {
+	public static final field $stable I
+	public fun <init> ()V
+	public fun <init> (Landroidx/compose/runtime/State;)V
+	public synthetic fun <init> (Landroidx/compose/runtime/State;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Landroidx/compose/runtime/State;
+	public final fun copy (Landroidx/compose/runtime/State;)Lcom/chrisjenx/yakcov/strings/Phone;
+	public static synthetic fun copy$default (Lcom/chrisjenx/yakcov/strings/Phone;Landroidx/compose/runtime/State;ILjava/lang/Object;)Lcom/chrisjenx/yakcov/strings/Phone;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDefaultRegion ()Landroidx/compose/runtime/State;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public synthetic fun validate (Ljava/lang/Object;)Lcom/chrisjenx/yakcov/ValidationResult;
+	public fun validate (Ljava/lang/String;)Lcom/chrisjenx/yakcov/ValidationResult;
+}
+
+public final class com/chrisjenx/yakcov/strings/PhoneFormat : com/chrisjenx/yakcov/ValueValidatorRule {
+	public static final field $stable I
+	public static final field INSTANCE Lcom/chrisjenx/yakcov/strings/PhoneFormat;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public synthetic fun validate (Ljava/lang/Object;)Lcom/chrisjenx/yakcov/ValidationResult;
+	public fun validate (Ljava/lang/String;)Lcom/chrisjenx/yakcov/ValidationResult;
+}
+
+public final class com/chrisjenx/yakcov/strings/Required : com/chrisjenx/yakcov/ValueValidatorRule {
+	public static final field $stable I
+	public static final field INSTANCE Lcom/chrisjenx/yakcov/strings/Required;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public synthetic fun validate (Ljava/lang/Object;)Lcom/chrisjenx/yakcov/ValidationResult;
+	public fun validate (Ljava/lang/String;)Lcom/chrisjenx/yakcov/ValidationResult;
+}
+
+public final class com/chrisjenx/yakcov/strings/StringValueValidatorRulesKt {
+	public static final fun PasswordMatchesStrings (Lcom/chrisjenx/yakcov/ValueValidator;)Lcom/chrisjenx/yakcov/ValueValidatorRule;
+	public static final fun PasswordMatchesTextFieldValue (Lcom/chrisjenx/yakcov/ValueValidator;)Lcom/chrisjenx/yakcov/ValueValidatorRule;
+}
+
+public final class com/chrisjenx/yakcov/strings/TextFieldValueValidator : com/chrisjenx/yakcov/ValueValidator {
+	public static final field $stable I
+	public fun <init> ()V
+	public fun <init> (Landroidx/compose/runtime/MutableState;Ljava/util/List;ZZLjava/lang/String;)V
+	public synthetic fun <init> (Landroidx/compose/runtime/MutableState;Ljava/util/List;ZZLjava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/util/List;ZZLjava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/util/List;ZZLjava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun onFocusCursorToEnd (Landroidx/compose/ui/Modifier;Lkotlinx/coroutines/CoroutineScope;ZLandroidx/compose/runtime/Composer;II)Landroidx/compose/ui/Modifier;
+	public final fun onValueChange (Ljava/lang/String;)V
+	public fun toString ()Ljava/lang/String;
+	public final fun validate (Ljava/lang/String;)Z
+	public static synthetic fun validate$default (Lcom/chrisjenx/yakcov/strings/TextFieldValueValidator;Ljava/lang/String;ILjava/lang/Object;)Z
+}
+
+public final class com/chrisjenx/yakcov/strings/TextFieldValueValidatorKt {
+	public static final fun rememberTextFieldValueValidator (Landroidx/compose/runtime/MutableState;Ljava/util/List;ZZLjava/lang/String;Landroidx/compose/runtime/Composer;II)Lcom/chrisjenx/yakcov/strings/TextFieldValueValidator;
+	public static final fun rememberTextFieldValueValidator (Ljava/lang/String;Ljava/util/List;ZZLjava/lang/String;Landroidx/compose/runtime/Composer;II)Lcom/chrisjenx/yakcov/strings/TextFieldValueValidator;
+}
+
+public final class com/chrisjenx/yakcov/strings/YearValidation : com/chrisjenx/yakcov/ValueValidatorRule {
+	public static final field $stable I
+	public fun <init> (Landroidx/compose/runtime/State;)V
+	public fun <init> (Lkotlinx/datetime/LocalDate;)V
+	public final fun component1 ()Landroidx/compose/runtime/State;
+	public final fun copy (Landroidx/compose/runtime/State;)Lcom/chrisjenx/yakcov/strings/YearValidation;
+	public static synthetic fun copy$default (Lcom/chrisjenx/yakcov/strings/YearValidation;Landroidx/compose/runtime/State;ILjava/lang/Object;)Lcom/chrisjenx/yakcov/strings/YearValidation;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getLocalDate ()Landroidx/compose/runtime/State;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public synthetic fun validate (Ljava/lang/Object;)Lcom/chrisjenx/yakcov/ValidationResult;
+	public fun validate (Ljava/lang/String;)Lcom/chrisjenx/yakcov/ValidationResult;
+}
+
+public final class yakcov/library/generated/resources/ActualResourceCollectorsKt {
+	public static final fun getAllDrawableResources (Lyakcov/library/generated/resources/Res;)Ljava/util/Map;
+	public static final fun getAllFontResources (Lyakcov/library/generated/resources/Res;)Ljava/util/Map;
+	public static final fun getAllPluralStringResources (Lyakcov/library/generated/resources/Res;)Ljava/util/Map;
+	public static final fun getAllStringArrayResources (Lyakcov/library/generated/resources/Res;)Ljava/util/Map;
+	public static final fun getAllStringResources (Lyakcov/library/generated/resources/Res;)Ljava/util/Map;
+}
+
+public final class yakcov/library/generated/resources/Res {
+	public static final field $stable I
+	public static final field INSTANCE Lyakcov/library/generated/resources/Res;
+	public final fun getUri (Ljava/lang/String;)Ljava/lang/String;
+	public final fun readBytes (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class yakcov/library/generated/resources/Res$array {
+	public static final field $stable I
+	public static final field INSTANCE Lyakcov/library/generated/resources/Res$array;
+}
+
+public final class yakcov/library/generated/resources/Res$drawable {
+	public static final field $stable I
+	public static final field INSTANCE Lyakcov/library/generated/resources/Res$drawable;
+}
+
+public final class yakcov/library/generated/resources/Res$font {
+	public static final field $stable I
+	public static final field INSTANCE Lyakcov/library/generated/resources/Res$font;
+}
+
+public final class yakcov/library/generated/resources/Res$plurals {
+	public static final field $stable I
+	public static final field INSTANCE Lyakcov/library/generated/resources/Res$plurals;
+}
+
+public final class yakcov/library/generated/resources/Res$string {
+	public static final field $stable I
+	public static final field INSTANCE Lyakcov/library/generated/resources/Res$string;
+}
+
+public final class yakcov/library/generated/resources/String0_commonMainKt {
+	public static final fun getRuleDay (Lyakcov/library/generated/resources/Res$string;)Lorg/jetbrains/compose/resources/StringResource;
+	public static final fun getRuleDecimal (Lyakcov/library/generated/resources/Res$string;)Lorg/jetbrains/compose/resources/StringResource;
+	public static final fun getRuleEmail (Lyakcov/library/generated/resources/Res$string;)Lorg/jetbrains/compose/resources/StringResource;
+	public static final fun getRuleHexColor (Lyakcov/library/generated/resources/Res$string;)Lorg/jetbrains/compose/resources/StringResource;
+	public static final fun getRuleInList (Lyakcov/library/generated/resources/Res$string;)Lorg/jetbrains/compose/resources/StringResource;
+	public static final fun getRuleInvalidDate (Lyakcov/library/generated/resources/Res$string;)Lorg/jetbrains/compose/resources/StringResource;
+	public static final fun getRuleIsChecked (Lyakcov/library/generated/resources/Res$string;)Lorg/jetbrains/compose/resources/StringResource;
+	public static final fun getRuleIsEmptyList (Lyakcov/library/generated/resources/Res$string;)Lorg/jetbrains/compose/resources/StringResource;
+	public static final fun getRuleIsNotChecked (Lyakcov/library/generated/resources/Res$string;)Lorg/jetbrains/compose/resources/StringResource;
+	public static final fun getRuleMaxLength (Lyakcov/library/generated/resources/Res$string;)Lorg/jetbrains/compose/resources/StringResource;
+	public static final fun getRuleMaxValue (Lyakcov/library/generated/resources/Res$string;)Lorg/jetbrains/compose/resources/StringResource;
+	public static final fun getRuleMinLength (Lyakcov/library/generated/resources/Res$string;)Lorg/jetbrains/compose/resources/StringResource;
+	public static final fun getRuleMinLengthNoWhitespace (Lyakcov/library/generated/resources/Res$string;)Lorg/jetbrains/compose/resources/StringResource;
+	public static final fun getRuleMinValue (Lyakcov/library/generated/resources/Res$string;)Lorg/jetbrains/compose/resources/StringResource;
+	public static final fun getRuleMonth (Lyakcov/library/generated/resources/Res$string;)Lorg/jetbrains/compose/resources/StringResource;
+	public static final fun getRuleNotEmptyList (Lyakcov/library/generated/resources/Res$string;)Lorg/jetbrains/compose/resources/StringResource;
+	public static final fun getRuleNotNull (Lyakcov/library/generated/resources/Res$string;)Lorg/jetbrains/compose/resources/StringResource;
+	public static final fun getRuleNumeric (Lyakcov/library/generated/resources/Res$string;)Lorg/jetbrains/compose/resources/StringResource;
+	public static final fun getRulePasswords (Lyakcov/library/generated/resources/Res$string;)Lorg/jetbrains/compose/resources/StringResource;
+	public static final fun getRulePhone (Lyakcov/library/generated/resources/Res$string;)Lorg/jetbrains/compose/resources/StringResource;
+	public static final fun getRuleRequired (Lyakcov/library/generated/resources/Res$string;)Lorg/jetbrains/compose/resources/StringResource;
+	public static final fun getRuleYear (Lyakcov/library/generated/resources/Res$string;)Lorg/jetbrains/compose/resources/StringResource;
+}
+

--- a/library/api/jvm/library.api
+++ b/library/api/jvm/library.api
@@ -1,0 +1,692 @@
+public final class com/chrisjenx/yakcov/FieldValidationState {
+	public static final field $stable I
+	public static final field Companion Lcom/chrisjenx/yakcov/FieldValidationState$Companion;
+	public fun <init> ()V
+	public fun <init> (Lcom/chrisjenx/yakcov/ValidationResult$Outcome;ZLcom/chrisjenx/yakcov/ValidationResult;)V
+	public synthetic fun <init> (Lcom/chrisjenx/yakcov/ValidationResult$Outcome;ZLcom/chrisjenx/yakcov/ValidationResult;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lcom/chrisjenx/yakcov/ValidationResult$Outcome;
+	public final fun component2 ()Z
+	public final fun component3 ()Lcom/chrisjenx/yakcov/ValidationResult;
+	public final fun copy (Lcom/chrisjenx/yakcov/ValidationResult$Outcome;ZLcom/chrisjenx/yakcov/ValidationResult;)Lcom/chrisjenx/yakcov/FieldValidationState;
+	public static synthetic fun copy$default (Lcom/chrisjenx/yakcov/FieldValidationState;Lcom/chrisjenx/yakcov/ValidationResult$Outcome;ZLcom/chrisjenx/yakcov/ValidationResult;ILjava/lang/Object;)Lcom/chrisjenx/yakcov/FieldValidationState;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getResult ()Lcom/chrisjenx/yakcov/ValidationResult;
+	public final fun getSeverity ()Lcom/chrisjenx/yakcov/ValidationResult$Outcome;
+	public final fun getShowError ()Z
+	public fun hashCode ()I
+	public final fun isError ()Z
+	public final fun isWarning ()Z
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class com/chrisjenx/yakcov/FieldValidationState$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field $stable I
+	public static final field INSTANCE Lcom/chrisjenx/yakcov/FieldValidationState$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/chrisjenx/yakcov/FieldValidationState;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/chrisjenx/yakcov/FieldValidationState;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/chrisjenx/yakcov/FieldValidationState$Companion {
+	public final fun getPristine ()Lcom/chrisjenx/yakcov/FieldValidationState;
+	public final fun getSaver ()Landroidx/compose/runtime/saveable/Saver;
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/chrisjenx/yakcov/FieldValidationStateKt {
+	public static final fun hasNoErrors (Ljava/util/List;)Z
+	public static final fun supportingText (Lcom/chrisjenx/yakcov/FieldValidationState;Ljava/lang/String;Landroidx/compose/runtime/Composer;II)Lkotlin/jvm/functions/Function2;
+	public static final fun text (Lcom/chrisjenx/yakcov/FieldValidationState;Ljava/lang/String;Landroidx/compose/runtime/Composer;II)Ljava/lang/String;
+	public static final fun toFieldState (Lcom/chrisjenx/yakcov/ValueValidatorRule;Ljava/lang/Object;Z)Lcom/chrisjenx/yakcov/FieldValidationState;
+	public static final fun toFieldState (Ljava/util/List;Ljava/lang/Object;Z)Lcom/chrisjenx/yakcov/FieldValidationState;
+}
+
+public final class com/chrisjenx/yakcov/FieldValidator {
+	public static final field $stable I
+	public fun <init> (Ljava/lang/Object;Ljava/util/List;ZLcom/chrisjenx/yakcov/FieldValidatorObserver;)V
+	public synthetic fun <init> (Ljava/lang/Object;Ljava/util/List;ZLcom/chrisjenx/yakcov/FieldValidatorObserver;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getAttempts ()I
+	public final fun getState ()Lcom/chrisjenx/yakcov/FieldValidationState;
+	public final fun getValue ()Ljava/lang/Object;
+	public final fun onFocusLost ()Z
+	public final fun onValueChange (Ljava/lang/Object;)V
+	public final fun reset ()V
+	public final fun reset (Ljava/lang/Object;)V
+	public final fun validate ()Z
+}
+
+public abstract interface class com/chrisjenx/yakcov/FieldValidatorEvent {
+	public abstract fun getState ()Lcom/chrisjenx/yakcov/FieldValidationState;
+	public abstract fun getValue ()Ljava/lang/Object;
+}
+
+public final class com/chrisjenx/yakcov/FieldValidatorEvent$Reset : com/chrisjenx/yakcov/FieldValidatorEvent {
+	public static final field $stable I
+	public fun <init> (Ljava/lang/Object;Lcom/chrisjenx/yakcov/FieldValidationState;)V
+	public final fun component1 ()Ljava/lang/Object;
+	public final fun component2 ()Lcom/chrisjenx/yakcov/FieldValidationState;
+	public final fun copy (Ljava/lang/Object;Lcom/chrisjenx/yakcov/FieldValidationState;)Lcom/chrisjenx/yakcov/FieldValidatorEvent$Reset;
+	public static synthetic fun copy$default (Lcom/chrisjenx/yakcov/FieldValidatorEvent$Reset;Ljava/lang/Object;Lcom/chrisjenx/yakcov/FieldValidationState;ILjava/lang/Object;)Lcom/chrisjenx/yakcov/FieldValidatorEvent$Reset;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getState ()Lcom/chrisjenx/yakcov/FieldValidationState;
+	public fun getValue ()Ljava/lang/Object;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/chrisjenx/yakcov/FieldValidatorEvent$Validated : com/chrisjenx/yakcov/FieldValidatorEvent {
+	public static final field $stable I
+	public fun <init> (Ljava/lang/Object;Lcom/chrisjenx/yakcov/FieldValidationState;)V
+	public final fun component1 ()Ljava/lang/Object;
+	public final fun component2 ()Lcom/chrisjenx/yakcov/FieldValidationState;
+	public final fun copy (Ljava/lang/Object;Lcom/chrisjenx/yakcov/FieldValidationState;)Lcom/chrisjenx/yakcov/FieldValidatorEvent$Validated;
+	public static synthetic fun copy$default (Lcom/chrisjenx/yakcov/FieldValidatorEvent$Validated;Ljava/lang/Object;Lcom/chrisjenx/yakcov/FieldValidationState;ILjava/lang/Object;)Lcom/chrisjenx/yakcov/FieldValidatorEvent$Validated;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getState ()Lcom/chrisjenx/yakcov/FieldValidationState;
+	public fun getValue ()Ljava/lang/Object;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/chrisjenx/yakcov/FieldValidatorEvent$ValueChanged : com/chrisjenx/yakcov/FieldValidatorEvent {
+	public static final field $stable I
+	public fun <init> (Ljava/lang/Object;Lcom/chrisjenx/yakcov/FieldValidationState;)V
+	public final fun component1 ()Ljava/lang/Object;
+	public final fun component2 ()Lcom/chrisjenx/yakcov/FieldValidationState;
+	public final fun copy (Ljava/lang/Object;Lcom/chrisjenx/yakcov/FieldValidationState;)Lcom/chrisjenx/yakcov/FieldValidatorEvent$ValueChanged;
+	public static synthetic fun copy$default (Lcom/chrisjenx/yakcov/FieldValidatorEvent$ValueChanged;Ljava/lang/Object;Lcom/chrisjenx/yakcov/FieldValidationState;ILjava/lang/Object;)Lcom/chrisjenx/yakcov/FieldValidatorEvent$ValueChanged;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getState ()Lcom/chrisjenx/yakcov/FieldValidationState;
+	public fun getValue ()Ljava/lang/Object;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/chrisjenx/yakcov/FieldValidatorKt {
+	public static final fun validate (Ljava/util/List;)Z
+}
+
+public abstract interface class com/chrisjenx/yakcov/FieldValidatorObserver {
+	public abstract fun onEvent (Lcom/chrisjenx/yakcov/FieldValidatorEvent;)V
+}
+
+public final class com/chrisjenx/yakcov/ModifiersKt {
+	public static final fun onFocusCursorToEnd (Landroidx/compose/ui/Modifier;Landroidx/compose/ui/text/input/TextFieldValue;Lkotlin/jvm/functions/Function1;Lkotlinx/coroutines/CoroutineScope;ZLandroidx/compose/runtime/Composer;II)Landroidx/compose/ui/Modifier;
+	public static final fun onFocusLost (Landroidx/compose/ui/Modifier;Lkotlin/jvm/functions/Function0;)Landroidx/compose/ui/Modifier;
+	public static final fun shakeOnInvalid (Landroidx/compose/ui/Modifier;ZI)Landroidx/compose/ui/Modifier;
+	public static final fun validationBehavior (Landroidx/compose/ui/Modifier;ZLjava/lang/Integer;Lkotlin/jvm/functions/Function0;)Landroidx/compose/ui/Modifier;
+	public static synthetic fun validationBehavior$default (Landroidx/compose/ui/Modifier;ZLjava/lang/Integer;Lkotlin/jvm/functions/Function0;ILjava/lang/Object;)Landroidx/compose/ui/Modifier;
+	public static final fun validationConfig (Landroidx/compose/ui/Modifier;Lcom/chrisjenx/yakcov/ValueValidator;ZZZ)Landroidx/compose/ui/Modifier;
+	public static synthetic fun validationConfig$default (Landroidx/compose/ui/Modifier;Lcom/chrisjenx/yakcov/ValueValidator;ZZZILjava/lang/Object;)Landroidx/compose/ui/Modifier;
+}
+
+public final class com/chrisjenx/yakcov/Optional : com/chrisjenx/yakcov/ValueValidatorRule {
+	public static final field $stable I
+	public fun <init> (Landroidx/compose/runtime/State;Lcom/chrisjenx/yakcov/ValueValidatorRule;)V
+	public fun <init> (ZLcom/chrisjenx/yakcov/ValueValidatorRule;)V
+	public fun validate (Ljava/lang/Object;)Lcom/chrisjenx/yakcov/ValidationResult;
+}
+
+public final class com/chrisjenx/yakcov/RegexExtKt {
+	public static final fun isEmail (Ljava/lang/String;)Z
+	public static final fun isPhoneNumber (Ljava/lang/String;Ljava/lang/String;)Z
+	public static synthetic fun isPhoneNumber$default (Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Z
+	public static final fun isPhoneNumberFormat (Ljava/lang/String;)Z
+}
+
+public final class com/chrisjenx/yakcov/RegularValidationResult : com/chrisjenx/yakcov/ValidationResult {
+	public static final field $stable I
+	public static final field Companion Lcom/chrisjenx/yakcov/RegularValidationResult$Companion;
+	public synthetic fun <init> (Ljava/lang/String;Lcom/chrisjenx/yakcov/ValidationResult$Outcome;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun copy (Ljava/lang/String;Lcom/chrisjenx/yakcov/ValidationResult$Outcome;)Lcom/chrisjenx/yakcov/RegularValidationResult;
+	public static synthetic fun copy$default (Lcom/chrisjenx/yakcov/RegularValidationResult;Ljava/lang/String;Lcom/chrisjenx/yakcov/ValidationResult$Outcome;ILjava/lang/Object;)Lcom/chrisjenx/yakcov/RegularValidationResult;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun format (Landroidx/compose/runtime/Composer;I)Ljava/lang/String;
+	public fun hashCode ()I
+	public fun messageOrNull ()Ljava/lang/String;
+	public fun outcome ()Lcom/chrisjenx/yakcov/ValidationResult$Outcome;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/chrisjenx/yakcov/RegularValidationResult$Companion {
+	public final fun error (Ljava/lang/String;)Lcom/chrisjenx/yakcov/RegularValidationResult;
+	public final fun info (Ljava/lang/String;)Lcom/chrisjenx/yakcov/RegularValidationResult;
+	public final fun success (Ljava/lang/String;)Lcom/chrisjenx/yakcov/RegularValidationResult;
+	public static synthetic fun success$default (Lcom/chrisjenx/yakcov/RegularValidationResult$Companion;Ljava/lang/String;ILjava/lang/Object;)Lcom/chrisjenx/yakcov/RegularValidationResult;
+	public final fun warning (Ljava/lang/String;)Lcom/chrisjenx/yakcov/RegularValidationResult;
+}
+
+public final class com/chrisjenx/yakcov/ResourceValidationResult : com/chrisjenx/yakcov/ValidationResult {
+	public static final field $stable I
+	public static final field Companion Lcom/chrisjenx/yakcov/ResourceValidationResult$Companion;
+	public synthetic fun <init> (Lorg/jetbrains/compose/resources/StringResource;Lcom/chrisjenx/yakcov/ValidationResult$Outcome;[Ljava/lang/Object;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun copy (Lorg/jetbrains/compose/resources/StringResource;Ljava/util/List;Lcom/chrisjenx/yakcov/ValidationResult$Outcome;)Lcom/chrisjenx/yakcov/ResourceValidationResult;
+	public static synthetic fun copy$default (Lcom/chrisjenx/yakcov/ResourceValidationResult;Lorg/jetbrains/compose/resources/StringResource;Ljava/util/List;Lcom/chrisjenx/yakcov/ValidationResult$Outcome;ILjava/lang/Object;)Lcom/chrisjenx/yakcov/ResourceValidationResult;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun format (Landroidx/compose/runtime/Composer;I)Ljava/lang/String;
+	public fun hashCode ()I
+	public fun messageOrNull ()Ljava/lang/String;
+	public fun outcome ()Lcom/chrisjenx/yakcov/ValidationResult$Outcome;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/chrisjenx/yakcov/ResourceValidationResult$Companion {
+	public final fun error (Lorg/jetbrains/compose/resources/StringResource;[Ljava/lang/Object;)Lcom/chrisjenx/yakcov/ResourceValidationResult;
+	public final fun info (Lorg/jetbrains/compose/resources/StringResource;[Ljava/lang/Object;)Lcom/chrisjenx/yakcov/ResourceValidationResult;
+	public final fun success (Lorg/jetbrains/compose/resources/StringResource;[Ljava/lang/Object;)Lcom/chrisjenx/yakcov/ResourceValidationResult;
+	public static synthetic fun success$default (Lcom/chrisjenx/yakcov/ResourceValidationResult$Companion;Lorg/jetbrains/compose/resources/StringResource;[Ljava/lang/Object;ILjava/lang/Object;)Lcom/chrisjenx/yakcov/ResourceValidationResult;
+	public final fun warning (Lorg/jetbrains/compose/resources/StringResource;[Ljava/lang/Object;)Lcom/chrisjenx/yakcov/ResourceValidationResult;
+}
+
+public final class com/chrisjenx/yakcov/RuleCombinatorsKt {
+	public static final fun onlyWhen (Lcom/chrisjenx/yakcov/ValueValidatorRule;Landroidx/compose/runtime/State;)Lcom/chrisjenx/yakcov/ValueValidatorRule;
+	public static final fun onlyWhen (Lcom/chrisjenx/yakcov/ValueValidatorRule;Z)Lcom/chrisjenx/yakcov/ValueValidatorRule;
+}
+
+public final class com/chrisjenx/yakcov/ShakingState {
+	public static final field $stable I
+	public fun <init> (Lcom/chrisjenx/yakcov/ShakingState$Strength;Lcom/chrisjenx/yakcov/ShakingState$Direction;)V
+	public final fun getXPosition ()Landroidx/compose/animation/core/Animatable;
+	public final fun shake (ILkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun shake$default (Lcom/chrisjenx/yakcov/ShakingState;ILkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+}
+
+public final class com/chrisjenx/yakcov/ShakingState$Direction : java/lang/Enum {
+	public static final field LEFT Lcom/chrisjenx/yakcov/ShakingState$Direction;
+	public static final field LEFT_THEN_RIGHT Lcom/chrisjenx/yakcov/ShakingState$Direction;
+	public static final field RIGHT Lcom/chrisjenx/yakcov/ShakingState$Direction;
+	public static final field RIGHT_THEN_LEFT Lcom/chrisjenx/yakcov/ShakingState$Direction;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lcom/chrisjenx/yakcov/ShakingState$Direction;
+	public static fun values ()[Lcom/chrisjenx/yakcov/ShakingState$Direction;
+}
+
+public abstract class com/chrisjenx/yakcov/ShakingState$Strength {
+	public static final field $stable I
+	public synthetic fun <init> (FLkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getValue ()F
+}
+
+public final class com/chrisjenx/yakcov/ShakingState$Strength$Custom : com/chrisjenx/yakcov/ShakingState$Strength {
+	public static final field $stable I
+	public fun <init> (F)V
+	public final fun component1 ()F
+	public final fun copy (F)Lcom/chrisjenx/yakcov/ShakingState$Strength$Custom;
+	public static synthetic fun copy$default (Lcom/chrisjenx/yakcov/ShakingState$Strength$Custom;FILjava/lang/Object;)Lcom/chrisjenx/yakcov/ShakingState$Strength$Custom;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getStrength ()F
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/chrisjenx/yakcov/ShakingState$Strength$Normal : com/chrisjenx/yakcov/ShakingState$Strength {
+	public static final field $stable I
+	public static final field INSTANCE Lcom/chrisjenx/yakcov/ShakingState$Strength$Normal;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/chrisjenx/yakcov/ShakingState$Strength$Strong : com/chrisjenx/yakcov/ShakingState$Strength {
+	public static final field $stable I
+	public static final field INSTANCE Lcom/chrisjenx/yakcov/ShakingState$Strength$Strong;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/chrisjenx/yakcov/ShakingStateKt {
+	public static final fun rememberShakingState (Lcom/chrisjenx/yakcov/ShakingState$Strength;Lcom/chrisjenx/yakcov/ShakingState$Direction;Landroidx/compose/runtime/Composer;II)Lcom/chrisjenx/yakcov/ShakingState;
+	public static final fun shakable (Landroidx/compose/ui/Modifier;Lcom/chrisjenx/yakcov/ShakingState;)Landroidx/compose/ui/Modifier;
+}
+
+public abstract interface class com/chrisjenx/yakcov/ValidationResult {
+	public abstract fun format (Landroidx/compose/runtime/Composer;I)Ljava/lang/String;
+	public fun messageOrNull ()Ljava/lang/String;
+	public fun outcome ()Lcom/chrisjenx/yakcov/ValidationResult$Outcome;
+}
+
+public final class com/chrisjenx/yakcov/ValidationResult$DefaultImpls {
+	public static fun messageOrNull (Lcom/chrisjenx/yakcov/ValidationResult;)Ljava/lang/String;
+	public static fun outcome (Lcom/chrisjenx/yakcov/ValidationResult;)Lcom/chrisjenx/yakcov/ValidationResult$Outcome;
+}
+
+public final class com/chrisjenx/yakcov/ValidationResult$Outcome : java/lang/Enum {
+	public static final field Companion Lcom/chrisjenx/yakcov/ValidationResult$Outcome$Companion;
+	public static final field ERROR Lcom/chrisjenx/yakcov/ValidationResult$Outcome;
+	public static final field INFO Lcom/chrisjenx/yakcov/ValidationResult$Outcome;
+	public static final field SUCCESS Lcom/chrisjenx/yakcov/ValidationResult$Outcome;
+	public static final field WARNING Lcom/chrisjenx/yakcov/ValidationResult$Outcome;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public final fun getSeverity ()S
+	public static fun valueOf (Ljava/lang/String;)Lcom/chrisjenx/yakcov/ValidationResult$Outcome;
+	public static fun values ()[Lcom/chrisjenx/yakcov/ValidationResult$Outcome;
+}
+
+public final class com/chrisjenx/yakcov/ValidationResult$Outcome$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public abstract class com/chrisjenx/yakcov/ValueValidator {
+	public static final field $stable I
+	public static final field Companion Lcom/chrisjenx/yakcov/ValueValidator$Companion;
+	public fun <init> (Landroidx/compose/runtime/MutableState;Ljava/util/List;ZZLjava/lang/String;Lkotlin/jvm/functions/Function2;)V
+	public synthetic fun <init> (Landroidx/compose/runtime/MutableState;Ljava/util/List;ZZLjava/lang/String;Lkotlin/jvm/functions/Function2;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun equals (Ljava/lang/Object;)Z
+	protected final fun getAlwaysShowRule ()Z
+	public final fun getErrorString (Landroidx/compose/runtime/Composer;I)Ljava/lang/String;
+	protected final fun getRules ()Ljava/util/List;
+	protected final fun getState ()Landroidx/compose/runtime/MutableState;
+	public final fun getValidationResultString (SLandroidx/compose/runtime/Composer;II)Ljava/lang/String;
+	public final fun getValidationResults ()Ljava/util/List;
+	protected final fun getValidationSeparator ()Ljava/lang/String;
+	public final fun getValue ()Ljava/lang/Object;
+	public fun hashCode ()I
+	public final fun isError ()Z
+	public final fun isValid ()Z
+	public fun onValueChange (Ljava/lang/Object;)V
+	public final fun outcome ()Lcom/chrisjenx/yakcov/ValidationResult$Outcome;
+	public fun reset ()V
+	public final fun setValue (Ljava/lang/Object;)V
+	public final fun shakeOnInvalid (Landroidx/compose/ui/Modifier;)Landroidx/compose/ui/Modifier;
+	public final fun supportingText (SLjava/lang/String;Landroidx/compose/runtime/Composer;II)Lkotlin/jvm/functions/Function2;
+	public fun toString ()Ljava/lang/String;
+	public fun validate (Ljava/lang/Object;)Z
+	public static synthetic fun validate$default (Lcom/chrisjenx/yakcov/ValueValidator;Ljava/lang/Object;ILjava/lang/Object;)Z
+	public final fun validateFocusChanged (Landroidx/compose/ui/Modifier;)Landroidx/compose/ui/Modifier;
+	public fun validateWithResult (Ljava/lang/Object;)Lcom/chrisjenx/yakcov/ValidationResult$Outcome;
+	public static synthetic fun validateWithResult$default (Lcom/chrisjenx/yakcov/ValueValidator;Ljava/lang/Object;ILjava/lang/Object;)Lcom/chrisjenx/yakcov/ValidationResult$Outcome;
+	public final fun validationConfig (Landroidx/compose/ui/Modifier;ZZZ)Landroidx/compose/ui/Modifier;
+	public static synthetic fun validationConfig$default (Lcom/chrisjenx/yakcov/ValueValidator;Landroidx/compose/ui/Modifier;ZZZILjava/lang/Object;)Landroidx/compose/ui/Modifier;
+}
+
+public final class com/chrisjenx/yakcov/ValueValidator$Companion {
+	public final fun getDefaultValidationSeparator ()Ljava/lang/String;
+	public final fun setDefaultValidationSeparator (Ljava/lang/String;)V
+}
+
+public final class com/chrisjenx/yakcov/ValueValidatorKt {
+	public static final fun validate (Ljava/util/List;)Z
+	public static final fun validateWithResult (Ljava/util/List;)Lcom/chrisjenx/yakcov/ValidationResult$Outcome;
+}
+
+public abstract interface class com/chrisjenx/yakcov/ValueValidatorRule {
+	public abstract fun validate (Ljava/lang/Object;)Lcom/chrisjenx/yakcov/ValidationResult;
+}
+
+public final class com/chrisjenx/yakcov/generic/GenericValueValidator : com/chrisjenx/yakcov/ValueValidator {
+	public static final field $stable I
+	public fun <init> (Landroidx/compose/runtime/MutableState;Ljava/util/List;ZZLjava/lang/String;)V
+	public synthetic fun <init> (Landroidx/compose/runtime/MutableState;Ljava/util/List;ZZLjava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+}
+
+public final class com/chrisjenx/yakcov/generic/GenericValueValidatorKt {
+	public static final fun rememberGenericValueValidator (Ljava/lang/Object;Ljava/util/List;ZZLjava/lang/String;Landroidx/compose/runtime/Composer;II)Lcom/chrisjenx/yakcov/generic/GenericValueValidator;
+}
+
+public final class com/chrisjenx/yakcov/generic/InList : com/chrisjenx/yakcov/ValueValidatorRule {
+	public static final field $stable I
+	public fun <init> (Landroidx/compose/runtime/State;)V
+	public fun <init> (Ljava/util/List;)V
+	public fun validate (Ljava/lang/Object;)Lcom/chrisjenx/yakcov/ValidationResult;
+}
+
+public final class com/chrisjenx/yakcov/generic/InRange : com/chrisjenx/yakcov/ValueValidatorRule {
+	public static final field $stable I
+	public fun <init> (Landroidx/compose/runtime/State;Landroidx/compose/runtime/State;)V
+	public fun <init> (Ljava/lang/Number;Ljava/lang/Number;)V
+	public fun validate (Ljava/lang/Number;)Lcom/chrisjenx/yakcov/ValidationResult;
+	public synthetic fun validate (Ljava/lang/Object;)Lcom/chrisjenx/yakcov/ValidationResult;
+}
+
+public final class com/chrisjenx/yakcov/generic/IsChecked : com/chrisjenx/yakcov/ValueValidatorRule {
+	public static final field $stable I
+	public static final field INSTANCE Lcom/chrisjenx/yakcov/generic/IsChecked;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public fun validate (Ljava/lang/Boolean;)Lcom/chrisjenx/yakcov/ValidationResult;
+	public synthetic fun validate (Ljava/lang/Object;)Lcom/chrisjenx/yakcov/ValidationResult;
+}
+
+public final class com/chrisjenx/yakcov/generic/IsNotChecked : com/chrisjenx/yakcov/ValueValidatorRule {
+	public static final field $stable I
+	public static final field INSTANCE Lcom/chrisjenx/yakcov/generic/IsNotChecked;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public fun validate (Ljava/lang/Boolean;)Lcom/chrisjenx/yakcov/ValidationResult;
+	public synthetic fun validate (Ljava/lang/Object;)Lcom/chrisjenx/yakcov/ValidationResult;
+}
+
+public final class com/chrisjenx/yakcov/generic/ListNotEmpty : com/chrisjenx/yakcov/ValueValidatorRule {
+	public static final field $stable I
+	public fun <init> ()V
+	public synthetic fun validate (Ljava/lang/Object;)Lcom/chrisjenx/yakcov/ValidationResult;
+	public fun validate (Ljava/util/List;)Lcom/chrisjenx/yakcov/ValidationResult;
+}
+
+public final class com/chrisjenx/yakcov/generic/Max : com/chrisjenx/yakcov/ValueValidatorRule {
+	public static final field $stable I
+	public fun <init> (Landroidx/compose/runtime/State;)V
+	public fun <init> (Ljava/lang/Number;)V
+	public fun validate (Ljava/lang/Number;)Lcom/chrisjenx/yakcov/ValidationResult;
+	public synthetic fun validate (Ljava/lang/Object;)Lcom/chrisjenx/yakcov/ValidationResult;
+}
+
+public final class com/chrisjenx/yakcov/generic/Min : com/chrisjenx/yakcov/ValueValidatorRule {
+	public static final field $stable I
+	public fun <init> (Landroidx/compose/runtime/State;)V
+	public fun <init> (Ljava/lang/Number;)V
+	public fun validate (Ljava/lang/Number;)Lcom/chrisjenx/yakcov/ValidationResult;
+	public synthetic fun validate (Ljava/lang/Object;)Lcom/chrisjenx/yakcov/ValidationResult;
+}
+
+public final class com/chrisjenx/yakcov/generic/Required : com/chrisjenx/yakcov/ValueValidatorRule {
+	public static final field $stable I
+	public fun <init> ()V
+	public fun validate (Ljava/lang/Object;)Lcom/chrisjenx/yakcov/ValidationResult;
+}
+
+public final class com/chrisjenx/yakcov/strings/DayValidation : com/chrisjenx/yakcov/ValueValidatorRule {
+	public static final field $stable I
+	public fun <init> (Landroidx/compose/runtime/State;)V
+	public fun <init> (Lkotlinx/datetime/LocalDate;)V
+	public final fun component1 ()Landroidx/compose/runtime/State;
+	public final fun copy (Landroidx/compose/runtime/State;)Lcom/chrisjenx/yakcov/strings/DayValidation;
+	public static synthetic fun copy$default (Lcom/chrisjenx/yakcov/strings/DayValidation;Landroidx/compose/runtime/State;ILjava/lang/Object;)Lcom/chrisjenx/yakcov/strings/DayValidation;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getLocalDate ()Landroidx/compose/runtime/State;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public synthetic fun validate (Ljava/lang/Object;)Lcom/chrisjenx/yakcov/ValidationResult;
+	public fun validate (Ljava/lang/String;)Lcom/chrisjenx/yakcov/ValidationResult;
+}
+
+public final class com/chrisjenx/yakcov/strings/Decimal : com/chrisjenx/yakcov/ValueValidatorRule {
+	public static final field $stable I
+	public static final field INSTANCE Lcom/chrisjenx/yakcov/strings/Decimal;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public synthetic fun validate (Ljava/lang/Object;)Lcom/chrisjenx/yakcov/ValidationResult;
+	public fun validate (Ljava/lang/String;)Lcom/chrisjenx/yakcov/ValidationResult;
+}
+
+public final class com/chrisjenx/yakcov/strings/Email : com/chrisjenx/yakcov/ValueValidatorRule {
+	public static final field $stable I
+	public static final field INSTANCE Lcom/chrisjenx/yakcov/strings/Email;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public synthetic fun validate (Ljava/lang/Object;)Lcom/chrisjenx/yakcov/ValidationResult;
+	public fun validate (Ljava/lang/String;)Lcom/chrisjenx/yakcov/ValidationResult;
+}
+
+public final class com/chrisjenx/yakcov/strings/HexColor : com/chrisjenx/yakcov/ValueValidatorRule {
+	public static final field $stable I
+	public static final field INSTANCE Lcom/chrisjenx/yakcov/strings/HexColor;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public synthetic fun validate (Ljava/lang/Object;)Lcom/chrisjenx/yakcov/ValidationResult;
+	public fun validate (Ljava/lang/String;)Lcom/chrisjenx/yakcov/ValidationResult;
+}
+
+public final class com/chrisjenx/yakcov/strings/MaxLength : com/chrisjenx/yakcov/ValueValidatorRule {
+	public static final field $stable I
+	public fun <init> (I)V
+	public fun <init> (Landroidx/compose/runtime/State;)V
+	public final fun component1 ()Landroidx/compose/runtime/State;
+	public final fun copy (Landroidx/compose/runtime/State;)Lcom/chrisjenx/yakcov/strings/MaxLength;
+	public static synthetic fun copy$default (Lcom/chrisjenx/yakcov/strings/MaxLength;Landroidx/compose/runtime/State;ILjava/lang/Object;)Lcom/chrisjenx/yakcov/strings/MaxLength;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getMaxLength ()Landroidx/compose/runtime/State;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public synthetic fun validate (Ljava/lang/Object;)Lcom/chrisjenx/yakcov/ValidationResult;
+	public fun validate (Ljava/lang/String;)Lcom/chrisjenx/yakcov/ValidationResult;
+}
+
+public final class com/chrisjenx/yakcov/strings/MaxValue : com/chrisjenx/yakcov/ValueValidatorRule {
+	public static final field $stable I
+	public fun <init> (Landroidx/compose/runtime/State;)V
+	public fun <init> (Ljava/lang/Number;)V
+	public final fun component1 ()Landroidx/compose/runtime/State;
+	public final fun copy (Landroidx/compose/runtime/State;)Lcom/chrisjenx/yakcov/strings/MaxValue;
+	public static synthetic fun copy$default (Lcom/chrisjenx/yakcov/strings/MaxValue;Landroidx/compose/runtime/State;ILjava/lang/Object;)Lcom/chrisjenx/yakcov/strings/MaxValue;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getMaxValue ()Landroidx/compose/runtime/State;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public synthetic fun validate (Ljava/lang/Object;)Lcom/chrisjenx/yakcov/ValidationResult;
+	public fun validate (Ljava/lang/String;)Lcom/chrisjenx/yakcov/ValidationResult;
+}
+
+public final class com/chrisjenx/yakcov/strings/MinLength : com/chrisjenx/yakcov/ValueValidatorRule {
+	public static final field $stable I
+	public fun <init> (IZZ)V
+	public synthetic fun <init> (IZZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Landroidx/compose/runtime/State;Landroidx/compose/runtime/State;Landroidx/compose/runtime/State;)V
+	public synthetic fun <init> (Landroidx/compose/runtime/State;Landroidx/compose/runtime/State;Landroidx/compose/runtime/State;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Landroidx/compose/runtime/State;
+	public final fun component2 ()Landroidx/compose/runtime/State;
+	public final fun component3 ()Landroidx/compose/runtime/State;
+	public final fun copy (Landroidx/compose/runtime/State;Landroidx/compose/runtime/State;Landroidx/compose/runtime/State;)Lcom/chrisjenx/yakcov/strings/MinLength;
+	public static synthetic fun copy$default (Lcom/chrisjenx/yakcov/strings/MinLength;Landroidx/compose/runtime/State;Landroidx/compose/runtime/State;Landroidx/compose/runtime/State;ILjava/lang/Object;)Lcom/chrisjenx/yakcov/strings/MinLength;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getIncludeWhiteSpace ()Landroidx/compose/runtime/State;
+	public final fun getMinLength ()Landroidx/compose/runtime/State;
+	public final fun getTrim ()Landroidx/compose/runtime/State;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public synthetic fun validate (Ljava/lang/Object;)Lcom/chrisjenx/yakcov/ValidationResult;
+	public fun validate (Ljava/lang/String;)Lcom/chrisjenx/yakcov/ValidationResult;
+}
+
+public final class com/chrisjenx/yakcov/strings/MinValue : com/chrisjenx/yakcov/ValueValidatorRule {
+	public static final field $stable I
+	public fun <init> (Landroidx/compose/runtime/State;)V
+	public fun <init> (Ljava/lang/Number;)V
+	public final fun component1 ()Landroidx/compose/runtime/State;
+	public final fun copy (Landroidx/compose/runtime/State;)Lcom/chrisjenx/yakcov/strings/MinValue;
+	public static synthetic fun copy$default (Lcom/chrisjenx/yakcov/strings/MinValue;Landroidx/compose/runtime/State;ILjava/lang/Object;)Lcom/chrisjenx/yakcov/strings/MinValue;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getMinValue ()Landroidx/compose/runtime/State;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public synthetic fun validate (Ljava/lang/Object;)Lcom/chrisjenx/yakcov/ValidationResult;
+	public fun validate (Ljava/lang/String;)Lcom/chrisjenx/yakcov/ValidationResult;
+}
+
+public final class com/chrisjenx/yakcov/strings/MonthValidation : com/chrisjenx/yakcov/ValueValidatorRule {
+	public static final field $stable I
+	public fun <init> (Landroidx/compose/runtime/State;)V
+	public fun <init> (Lkotlinx/datetime/LocalDate;)V
+	public final fun component1 ()Landroidx/compose/runtime/State;
+	public final fun copy (Landroidx/compose/runtime/State;)Lcom/chrisjenx/yakcov/strings/MonthValidation;
+	public static synthetic fun copy$default (Lcom/chrisjenx/yakcov/strings/MonthValidation;Landroidx/compose/runtime/State;ILjava/lang/Object;)Lcom/chrisjenx/yakcov/strings/MonthValidation;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getLocalDate ()Landroidx/compose/runtime/State;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public synthetic fun validate (Ljava/lang/Object;)Lcom/chrisjenx/yakcov/ValidationResult;
+	public fun validate (Ljava/lang/String;)Lcom/chrisjenx/yakcov/ValidationResult;
+}
+
+public final class com/chrisjenx/yakcov/strings/Numeric : com/chrisjenx/yakcov/ValueValidatorRule {
+	public static final field $stable I
+	public static final field INSTANCE Lcom/chrisjenx/yakcov/strings/Numeric;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public synthetic fun validate (Ljava/lang/Object;)Lcom/chrisjenx/yakcov/ValidationResult;
+	public fun validate (Ljava/lang/String;)Lcom/chrisjenx/yakcov/ValidationResult;
+}
+
+public final class com/chrisjenx/yakcov/strings/OneOf : com/chrisjenx/yakcov/ValueValidatorRule {
+	public static final field $stable I
+	public fun <init> (Landroidx/compose/runtime/State;ZZ)V
+	public synthetic fun <init> (Landroidx/compose/runtime/State;ZZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/util/Set;ZZ)V
+	public synthetic fun <init> (Ljava/util/Set;ZZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Landroidx/compose/runtime/State;
+	public final fun component2 ()Z
+	public final fun component3 ()Z
+	public final fun copy (Landroidx/compose/runtime/State;ZZ)Lcom/chrisjenx/yakcov/strings/OneOf;
+	public static synthetic fun copy$default (Lcom/chrisjenx/yakcov/strings/OneOf;Landroidx/compose/runtime/State;ZZILjava/lang/Object;)Lcom/chrisjenx/yakcov/strings/OneOf;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAllowed ()Landroidx/compose/runtime/State;
+	public final fun getIgnoreCase ()Z
+	public final fun getTrim ()Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public synthetic fun validate (Ljava/lang/Object;)Lcom/chrisjenx/yakcov/ValidationResult;
+	public fun validate (Ljava/lang/String;)Lcom/chrisjenx/yakcov/ValidationResult;
+}
+
+public final class com/chrisjenx/yakcov/strings/Phone : com/chrisjenx/yakcov/ValueValidatorRule {
+	public static final field $stable I
+	public fun <init> ()V
+	public fun <init> (Landroidx/compose/runtime/State;)V
+	public synthetic fun <init> (Landroidx/compose/runtime/State;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Landroidx/compose/runtime/State;
+	public final fun copy (Landroidx/compose/runtime/State;)Lcom/chrisjenx/yakcov/strings/Phone;
+	public static synthetic fun copy$default (Lcom/chrisjenx/yakcov/strings/Phone;Landroidx/compose/runtime/State;ILjava/lang/Object;)Lcom/chrisjenx/yakcov/strings/Phone;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDefaultRegion ()Landroidx/compose/runtime/State;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public synthetic fun validate (Ljava/lang/Object;)Lcom/chrisjenx/yakcov/ValidationResult;
+	public fun validate (Ljava/lang/String;)Lcom/chrisjenx/yakcov/ValidationResult;
+}
+
+public final class com/chrisjenx/yakcov/strings/PhoneFormat : com/chrisjenx/yakcov/ValueValidatorRule {
+	public static final field $stable I
+	public static final field INSTANCE Lcom/chrisjenx/yakcov/strings/PhoneFormat;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public synthetic fun validate (Ljava/lang/Object;)Lcom/chrisjenx/yakcov/ValidationResult;
+	public fun validate (Ljava/lang/String;)Lcom/chrisjenx/yakcov/ValidationResult;
+}
+
+public final class com/chrisjenx/yakcov/strings/Required : com/chrisjenx/yakcov/ValueValidatorRule {
+	public static final field $stable I
+	public static final field INSTANCE Lcom/chrisjenx/yakcov/strings/Required;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public synthetic fun validate (Ljava/lang/Object;)Lcom/chrisjenx/yakcov/ValidationResult;
+	public fun validate (Ljava/lang/String;)Lcom/chrisjenx/yakcov/ValidationResult;
+}
+
+public final class com/chrisjenx/yakcov/strings/StringValueValidatorRulesKt {
+	public static final fun PasswordMatchesStrings (Lcom/chrisjenx/yakcov/ValueValidator;)Lcom/chrisjenx/yakcov/ValueValidatorRule;
+	public static final fun PasswordMatchesTextFieldValue (Lcom/chrisjenx/yakcov/ValueValidator;)Lcom/chrisjenx/yakcov/ValueValidatorRule;
+}
+
+public final class com/chrisjenx/yakcov/strings/TextFieldValueValidator : com/chrisjenx/yakcov/ValueValidator {
+	public static final field $stable I
+	public fun <init> ()V
+	public fun <init> (Landroidx/compose/runtime/MutableState;Ljava/util/List;ZZLjava/lang/String;)V
+	public synthetic fun <init> (Landroidx/compose/runtime/MutableState;Ljava/util/List;ZZLjava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/util/List;ZZLjava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/util/List;ZZLjava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun onFocusCursorToEnd (Landroidx/compose/ui/Modifier;Lkotlinx/coroutines/CoroutineScope;ZLandroidx/compose/runtime/Composer;II)Landroidx/compose/ui/Modifier;
+	public final fun onValueChange (Ljava/lang/String;)V
+	public fun toString ()Ljava/lang/String;
+	public final fun validate (Ljava/lang/String;)Z
+	public static synthetic fun validate$default (Lcom/chrisjenx/yakcov/strings/TextFieldValueValidator;Ljava/lang/String;ILjava/lang/Object;)Z
+}
+
+public final class com/chrisjenx/yakcov/strings/TextFieldValueValidatorKt {
+	public static final fun rememberTextFieldValueValidator (Landroidx/compose/runtime/MutableState;Ljava/util/List;ZZLjava/lang/String;Landroidx/compose/runtime/Composer;II)Lcom/chrisjenx/yakcov/strings/TextFieldValueValidator;
+	public static final fun rememberTextFieldValueValidator (Ljava/lang/String;Ljava/util/List;ZZLjava/lang/String;Landroidx/compose/runtime/Composer;II)Lcom/chrisjenx/yakcov/strings/TextFieldValueValidator;
+}
+
+public final class com/chrisjenx/yakcov/strings/YearValidation : com/chrisjenx/yakcov/ValueValidatorRule {
+	public static final field $stable I
+	public fun <init> (Landroidx/compose/runtime/State;)V
+	public fun <init> (Lkotlinx/datetime/LocalDate;)V
+	public final fun component1 ()Landroidx/compose/runtime/State;
+	public final fun copy (Landroidx/compose/runtime/State;)Lcom/chrisjenx/yakcov/strings/YearValidation;
+	public static synthetic fun copy$default (Lcom/chrisjenx/yakcov/strings/YearValidation;Landroidx/compose/runtime/State;ILjava/lang/Object;)Lcom/chrisjenx/yakcov/strings/YearValidation;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getLocalDate ()Landroidx/compose/runtime/State;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public synthetic fun validate (Ljava/lang/Object;)Lcom/chrisjenx/yakcov/ValidationResult;
+	public fun validate (Ljava/lang/String;)Lcom/chrisjenx/yakcov/ValidationResult;
+}
+
+public final class yakcov/library/generated/resources/ActualResourceCollectorsKt {
+	public static final fun getAllDrawableResources (Lyakcov/library/generated/resources/Res;)Ljava/util/Map;
+	public static final fun getAllFontResources (Lyakcov/library/generated/resources/Res;)Ljava/util/Map;
+	public static final fun getAllPluralStringResources (Lyakcov/library/generated/resources/Res;)Ljava/util/Map;
+	public static final fun getAllStringArrayResources (Lyakcov/library/generated/resources/Res;)Ljava/util/Map;
+	public static final fun getAllStringResources (Lyakcov/library/generated/resources/Res;)Ljava/util/Map;
+}
+
+public final class yakcov/library/generated/resources/Res {
+	public static final field $stable I
+	public static final field INSTANCE Lyakcov/library/generated/resources/Res;
+	public final fun getUri (Ljava/lang/String;)Ljava/lang/String;
+	public final fun readBytes (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class yakcov/library/generated/resources/Res$array {
+	public static final field $stable I
+	public static final field INSTANCE Lyakcov/library/generated/resources/Res$array;
+}
+
+public final class yakcov/library/generated/resources/Res$drawable {
+	public static final field $stable I
+	public static final field INSTANCE Lyakcov/library/generated/resources/Res$drawable;
+}
+
+public final class yakcov/library/generated/resources/Res$font {
+	public static final field $stable I
+	public static final field INSTANCE Lyakcov/library/generated/resources/Res$font;
+}
+
+public final class yakcov/library/generated/resources/Res$plurals {
+	public static final field $stable I
+	public static final field INSTANCE Lyakcov/library/generated/resources/Res$plurals;
+}
+
+public final class yakcov/library/generated/resources/Res$string {
+	public static final field $stable I
+	public static final field INSTANCE Lyakcov/library/generated/resources/Res$string;
+}
+
+public final class yakcov/library/generated/resources/String0_commonMainKt {
+	public static final fun getRuleDay (Lyakcov/library/generated/resources/Res$string;)Lorg/jetbrains/compose/resources/StringResource;
+	public static final fun getRuleDecimal (Lyakcov/library/generated/resources/Res$string;)Lorg/jetbrains/compose/resources/StringResource;
+	public static final fun getRuleEmail (Lyakcov/library/generated/resources/Res$string;)Lorg/jetbrains/compose/resources/StringResource;
+	public static final fun getRuleHexColor (Lyakcov/library/generated/resources/Res$string;)Lorg/jetbrains/compose/resources/StringResource;
+	public static final fun getRuleInList (Lyakcov/library/generated/resources/Res$string;)Lorg/jetbrains/compose/resources/StringResource;
+	public static final fun getRuleInvalidDate (Lyakcov/library/generated/resources/Res$string;)Lorg/jetbrains/compose/resources/StringResource;
+	public static final fun getRuleIsChecked (Lyakcov/library/generated/resources/Res$string;)Lorg/jetbrains/compose/resources/StringResource;
+	public static final fun getRuleIsEmptyList (Lyakcov/library/generated/resources/Res$string;)Lorg/jetbrains/compose/resources/StringResource;
+	public static final fun getRuleIsNotChecked (Lyakcov/library/generated/resources/Res$string;)Lorg/jetbrains/compose/resources/StringResource;
+	public static final fun getRuleMaxLength (Lyakcov/library/generated/resources/Res$string;)Lorg/jetbrains/compose/resources/StringResource;
+	public static final fun getRuleMaxValue (Lyakcov/library/generated/resources/Res$string;)Lorg/jetbrains/compose/resources/StringResource;
+	public static final fun getRuleMinLength (Lyakcov/library/generated/resources/Res$string;)Lorg/jetbrains/compose/resources/StringResource;
+	public static final fun getRuleMinLengthNoWhitespace (Lyakcov/library/generated/resources/Res$string;)Lorg/jetbrains/compose/resources/StringResource;
+	public static final fun getRuleMinValue (Lyakcov/library/generated/resources/Res$string;)Lorg/jetbrains/compose/resources/StringResource;
+	public static final fun getRuleMonth (Lyakcov/library/generated/resources/Res$string;)Lorg/jetbrains/compose/resources/StringResource;
+	public static final fun getRuleNotEmptyList (Lyakcov/library/generated/resources/Res$string;)Lorg/jetbrains/compose/resources/StringResource;
+	public static final fun getRuleNotNull (Lyakcov/library/generated/resources/Res$string;)Lorg/jetbrains/compose/resources/StringResource;
+	public static final fun getRuleNumeric (Lyakcov/library/generated/resources/Res$string;)Lorg/jetbrains/compose/resources/StringResource;
+	public static final fun getRulePasswords (Lyakcov/library/generated/resources/Res$string;)Lorg/jetbrains/compose/resources/StringResource;
+	public static final fun getRulePhone (Lyakcov/library/generated/resources/Res$string;)Lorg/jetbrains/compose/resources/StringResource;
+	public static final fun getRuleRequired (Lyakcov/library/generated/resources/Res$string;)Lorg/jetbrains/compose/resources/StringResource;
+	public static final fun getRuleYear (Lyakcov/library/generated/resources/Res$string;)Lorg/jetbrains/compose/resources/StringResource;
+}
+

--- a/library/api/library.klib.api
+++ b/library/api/library.klib.api
@@ -1,0 +1,739 @@
+// Klib ABI Dump
+// Targets: [iosArm64, iosSimulatorArm64, js, wasmJs]
+// Rendering settings:
+// - Signature version: 2
+// - Show manifest properties: true
+// - Show declarations: true
+
+// Library unique name: <yakcov:library>
+abstract fun interface <#A: kotlin/Any?> com.chrisjenx.yakcov/FieldValidatorObserver { // com.chrisjenx.yakcov/FieldValidatorObserver|null[0]
+    abstract fun onEvent(com.chrisjenx.yakcov/FieldValidatorEvent<#A>) // com.chrisjenx.yakcov/FieldValidatorObserver.onEvent|onEvent(com.chrisjenx.yakcov.FieldValidatorEvent<1:0>){}[0]
+}
+
+abstract fun interface <#A: kotlin/Any?> com.chrisjenx.yakcov/ValueValidatorRule { // com.chrisjenx.yakcov/ValueValidatorRule|null[0]
+    abstract fun validate(#A): com.chrisjenx.yakcov/ValidationResult // com.chrisjenx.yakcov/ValueValidatorRule.validate|validate(1:0){}[0]
+}
+
+abstract interface com.chrisjenx.yakcov/ValidationResult { // com.chrisjenx.yakcov/ValidationResult|null[0]
+    abstract fun format(androidx.compose.runtime/Composer?, kotlin/Int): kotlin/String? // com.chrisjenx.yakcov/ValidationResult.format|format(androidx.compose.runtime.Composer?;kotlin.Int){}[0]
+    open fun messageOrNull(): kotlin/String? // com.chrisjenx.yakcov/ValidationResult.messageOrNull|messageOrNull(){}[0]
+    open fun outcome(): com.chrisjenx.yakcov/ValidationResult.Outcome // com.chrisjenx.yakcov/ValidationResult.outcome|outcome(){}[0]
+
+    final enum class Outcome : kotlin/Enum<com.chrisjenx.yakcov/ValidationResult.Outcome> { // com.chrisjenx.yakcov/ValidationResult.Outcome|null[0]
+        enum entry ERROR // com.chrisjenx.yakcov/ValidationResult.Outcome.ERROR|null[0]
+        enum entry INFO // com.chrisjenx.yakcov/ValidationResult.Outcome.INFO|null[0]
+        enum entry SUCCESS // com.chrisjenx.yakcov/ValidationResult.Outcome.SUCCESS|null[0]
+        enum entry WARNING // com.chrisjenx.yakcov/ValidationResult.Outcome.WARNING|null[0]
+
+        final val entries // com.chrisjenx.yakcov/ValidationResult.Outcome.entries|#static{}entries[0]
+            final fun <get-entries>(): kotlin.enums/EnumEntries<com.chrisjenx.yakcov/ValidationResult.Outcome> // com.chrisjenx.yakcov/ValidationResult.Outcome.entries.<get-entries>|<get-entries>#static(){}[0]
+        final val severity // com.chrisjenx.yakcov/ValidationResult.Outcome.severity|{}severity[0]
+            final fun <get-severity>(): kotlin/Short // com.chrisjenx.yakcov/ValidationResult.Outcome.severity.<get-severity>|<get-severity>(){}[0]
+
+        final fun valueOf(kotlin/String): com.chrisjenx.yakcov/ValidationResult.Outcome // com.chrisjenx.yakcov/ValidationResult.Outcome.valueOf|valueOf#static(kotlin.String){}[0]
+        final fun values(): kotlin/Array<com.chrisjenx.yakcov/ValidationResult.Outcome> // com.chrisjenx.yakcov/ValidationResult.Outcome.values|values#static(){}[0]
+
+        final object Companion : kotlinx.serialization.internal/SerializerFactory { // com.chrisjenx.yakcov/ValidationResult.Outcome.Companion|null[0]
+            final fun serializer(): kotlinx.serialization/KSerializer<com.chrisjenx.yakcov/ValidationResult.Outcome> // com.chrisjenx.yakcov/ValidationResult.Outcome.Companion.serializer|serializer(){}[0]
+            final fun serializer(kotlin/Array<out kotlinx.serialization/KSerializer<*>>...): kotlinx.serialization/KSerializer<*> // com.chrisjenx.yakcov/ValidationResult.Outcome.Companion.serializer|serializer(kotlin.Array<out|kotlinx.serialization.KSerializer<*>>...){}[0]
+        }
+    }
+}
+
+sealed interface <#A: kotlin/Any?> com.chrisjenx.yakcov/FieldValidatorEvent { // com.chrisjenx.yakcov/FieldValidatorEvent|null[0]
+    abstract val state // com.chrisjenx.yakcov/FieldValidatorEvent.state|{}state[0]
+        abstract fun <get-state>(): com.chrisjenx.yakcov/FieldValidationState // com.chrisjenx.yakcov/FieldValidatorEvent.state.<get-state>|<get-state>(){}[0]
+    abstract val value // com.chrisjenx.yakcov/FieldValidatorEvent.value|{}value[0]
+        abstract fun <get-value>(): #A // com.chrisjenx.yakcov/FieldValidatorEvent.value.<get-value>|<get-value>(){}[0]
+
+    final class <#A1: kotlin/Any?> Reset : com.chrisjenx.yakcov/FieldValidatorEvent<#A1> { // com.chrisjenx.yakcov/FieldValidatorEvent.Reset|null[0]
+        constructor <init>(#A1, com.chrisjenx.yakcov/FieldValidationState) // com.chrisjenx.yakcov/FieldValidatorEvent.Reset.<init>|<init>(1:0;com.chrisjenx.yakcov.FieldValidationState){}[0]
+
+        final val state // com.chrisjenx.yakcov/FieldValidatorEvent.Reset.state|{}state[0]
+            final fun <get-state>(): com.chrisjenx.yakcov/FieldValidationState // com.chrisjenx.yakcov/FieldValidatorEvent.Reset.state.<get-state>|<get-state>(){}[0]
+        final val value // com.chrisjenx.yakcov/FieldValidatorEvent.Reset.value|{}value[0]
+            final fun <get-value>(): #A1 // com.chrisjenx.yakcov/FieldValidatorEvent.Reset.value.<get-value>|<get-value>(){}[0]
+
+        final fun component1(): #A1 // com.chrisjenx.yakcov/FieldValidatorEvent.Reset.component1|component1(){}[0]
+        final fun component2(): com.chrisjenx.yakcov/FieldValidationState // com.chrisjenx.yakcov/FieldValidatorEvent.Reset.component2|component2(){}[0]
+        final fun copy(#A1 = ..., com.chrisjenx.yakcov/FieldValidationState = ...): com.chrisjenx.yakcov/FieldValidatorEvent.Reset<#A1> // com.chrisjenx.yakcov/FieldValidatorEvent.Reset.copy|copy(1:0;com.chrisjenx.yakcov.FieldValidationState){}[0]
+        final fun equals(kotlin/Any?): kotlin/Boolean // com.chrisjenx.yakcov/FieldValidatorEvent.Reset.equals|equals(kotlin.Any?){}[0]
+        final fun hashCode(): kotlin/Int // com.chrisjenx.yakcov/FieldValidatorEvent.Reset.hashCode|hashCode(){}[0]
+        final fun toString(): kotlin/String // com.chrisjenx.yakcov/FieldValidatorEvent.Reset.toString|toString(){}[0]
+    }
+
+    final class <#A1: kotlin/Any?> Validated : com.chrisjenx.yakcov/FieldValidatorEvent<#A1> { // com.chrisjenx.yakcov/FieldValidatorEvent.Validated|null[0]
+        constructor <init>(#A1, com.chrisjenx.yakcov/FieldValidationState) // com.chrisjenx.yakcov/FieldValidatorEvent.Validated.<init>|<init>(1:0;com.chrisjenx.yakcov.FieldValidationState){}[0]
+
+        final val state // com.chrisjenx.yakcov/FieldValidatorEvent.Validated.state|{}state[0]
+            final fun <get-state>(): com.chrisjenx.yakcov/FieldValidationState // com.chrisjenx.yakcov/FieldValidatorEvent.Validated.state.<get-state>|<get-state>(){}[0]
+        final val value // com.chrisjenx.yakcov/FieldValidatorEvent.Validated.value|{}value[0]
+            final fun <get-value>(): #A1 // com.chrisjenx.yakcov/FieldValidatorEvent.Validated.value.<get-value>|<get-value>(){}[0]
+
+        final fun component1(): #A1 // com.chrisjenx.yakcov/FieldValidatorEvent.Validated.component1|component1(){}[0]
+        final fun component2(): com.chrisjenx.yakcov/FieldValidationState // com.chrisjenx.yakcov/FieldValidatorEvent.Validated.component2|component2(){}[0]
+        final fun copy(#A1 = ..., com.chrisjenx.yakcov/FieldValidationState = ...): com.chrisjenx.yakcov/FieldValidatorEvent.Validated<#A1> // com.chrisjenx.yakcov/FieldValidatorEvent.Validated.copy|copy(1:0;com.chrisjenx.yakcov.FieldValidationState){}[0]
+        final fun equals(kotlin/Any?): kotlin/Boolean // com.chrisjenx.yakcov/FieldValidatorEvent.Validated.equals|equals(kotlin.Any?){}[0]
+        final fun hashCode(): kotlin/Int // com.chrisjenx.yakcov/FieldValidatorEvent.Validated.hashCode|hashCode(){}[0]
+        final fun toString(): kotlin/String // com.chrisjenx.yakcov/FieldValidatorEvent.Validated.toString|toString(){}[0]
+    }
+
+    final class <#A1: kotlin/Any?> ValueChanged : com.chrisjenx.yakcov/FieldValidatorEvent<#A1> { // com.chrisjenx.yakcov/FieldValidatorEvent.ValueChanged|null[0]
+        constructor <init>(#A1, com.chrisjenx.yakcov/FieldValidationState) // com.chrisjenx.yakcov/FieldValidatorEvent.ValueChanged.<init>|<init>(1:0;com.chrisjenx.yakcov.FieldValidationState){}[0]
+
+        final val state // com.chrisjenx.yakcov/FieldValidatorEvent.ValueChanged.state|{}state[0]
+            final fun <get-state>(): com.chrisjenx.yakcov/FieldValidationState // com.chrisjenx.yakcov/FieldValidatorEvent.ValueChanged.state.<get-state>|<get-state>(){}[0]
+        final val value // com.chrisjenx.yakcov/FieldValidatorEvent.ValueChanged.value|{}value[0]
+            final fun <get-value>(): #A1 // com.chrisjenx.yakcov/FieldValidatorEvent.ValueChanged.value.<get-value>|<get-value>(){}[0]
+
+        final fun component1(): #A1 // com.chrisjenx.yakcov/FieldValidatorEvent.ValueChanged.component1|component1(){}[0]
+        final fun component2(): com.chrisjenx.yakcov/FieldValidationState // com.chrisjenx.yakcov/FieldValidatorEvent.ValueChanged.component2|component2(){}[0]
+        final fun copy(#A1 = ..., com.chrisjenx.yakcov/FieldValidationState = ...): com.chrisjenx.yakcov/FieldValidatorEvent.ValueChanged<#A1> // com.chrisjenx.yakcov/FieldValidatorEvent.ValueChanged.copy|copy(1:0;com.chrisjenx.yakcov.FieldValidationState){}[0]
+        final fun equals(kotlin/Any?): kotlin/Boolean // com.chrisjenx.yakcov/FieldValidatorEvent.ValueChanged.equals|equals(kotlin.Any?){}[0]
+        final fun hashCode(): kotlin/Int // com.chrisjenx.yakcov/FieldValidatorEvent.ValueChanged.hashCode|hashCode(){}[0]
+        final fun toString(): kotlin/String // com.chrisjenx.yakcov/FieldValidatorEvent.ValueChanged.toString|toString(){}[0]
+    }
+}
+
+abstract class <#A: kotlin/Any?, #B: kotlin/Any?> com.chrisjenx.yakcov/ValueValidator { // com.chrisjenx.yakcov/ValueValidator|null[0]
+    constructor <init>(androidx.compose.runtime/MutableState<#A>, kotlin.collections/List<com.chrisjenx.yakcov/ValueValidatorRule<#B>>, kotlin/Boolean = ..., kotlin/Boolean = ..., kotlin/String = ..., kotlin/Function2<com.chrisjenx.yakcov/ValueValidatorRule<#B>, #A, com.chrisjenx.yakcov/ValidationResult>) // com.chrisjenx.yakcov/ValueValidator.<init>|<init>(androidx.compose.runtime.MutableState<1:0>;kotlin.collections.List<com.chrisjenx.yakcov.ValueValidatorRule<1:1>>;kotlin.Boolean;kotlin.Boolean;kotlin.String;kotlin.Function2<com.chrisjenx.yakcov.ValueValidatorRule<1:1>,1:0,com.chrisjenx.yakcov.ValidationResult>){}[0]
+
+    final val alwaysShowRule // com.chrisjenx.yakcov/ValueValidator.alwaysShowRule|{}alwaysShowRule[0]
+        final fun <get-alwaysShowRule>(): kotlin/Boolean // com.chrisjenx.yakcov/ValueValidator.alwaysShowRule.<get-alwaysShowRule>|<get-alwaysShowRule>(){}[0]
+    final val isValid // com.chrisjenx.yakcov/ValueValidator.isValid|{}isValid[0]
+        final fun <get-isValid>(): kotlin/Boolean // com.chrisjenx.yakcov/ValueValidator.isValid.<get-isValid>|<get-isValid>(){}[0]
+    final val rules // com.chrisjenx.yakcov/ValueValidator.rules|{}rules[0]
+        final fun <get-rules>(): kotlin.collections/List<com.chrisjenx.yakcov/ValueValidatorRule<#B>> // com.chrisjenx.yakcov/ValueValidator.rules.<get-rules>|<get-rules>(){}[0]
+    final val state // com.chrisjenx.yakcov/ValueValidator.state|{}state[0]
+        final fun <get-state>(): androidx.compose.runtime/MutableState<#A> // com.chrisjenx.yakcov/ValueValidator.state.<get-state>|<get-state>(){}[0]
+    final val validationResults // com.chrisjenx.yakcov/ValueValidator.validationResults|{}validationResults[0]
+        final fun <get-validationResults>(): kotlin.collections/List<com.chrisjenx.yakcov/ValidationResult> // com.chrisjenx.yakcov/ValueValidator.validationResults.<get-validationResults>|<get-validationResults>(){}[0]
+    final val validationSeparator // com.chrisjenx.yakcov/ValueValidator.validationSeparator|{}validationSeparator[0]
+        final fun <get-validationSeparator>(): kotlin/String // com.chrisjenx.yakcov/ValueValidator.validationSeparator.<get-validationSeparator>|<get-validationSeparator>(){}[0]
+
+    final var value // com.chrisjenx.yakcov/ValueValidator.value|{}value[0]
+        final fun <get-value>(): #A // com.chrisjenx.yakcov/ValueValidator.value.<get-value>|<get-value>(){}[0]
+        final fun <set-value>(#A) // com.chrisjenx.yakcov/ValueValidator.value.<set-value>|<set-value>(1:0){}[0]
+
+    final fun (androidx.compose.ui/Modifier).shakeOnInvalid(): androidx.compose.ui/Modifier // com.chrisjenx.yakcov/ValueValidator.shakeOnInvalid|shakeOnInvalid@androidx.compose.ui.Modifier(){}[0]
+    final fun (androidx.compose.ui/Modifier).validateFocusChanged(): androidx.compose.ui/Modifier // com.chrisjenx.yakcov/ValueValidator.validateFocusChanged|validateFocusChanged@androidx.compose.ui.Modifier(){}[0]
+    final fun (androidx.compose.ui/Modifier).validationConfig(kotlin/Boolean = ..., kotlin/Boolean = ..., kotlin/Boolean = ...): androidx.compose.ui/Modifier // com.chrisjenx.yakcov/ValueValidator.validationConfig|validationConfig@androidx.compose.ui.Modifier(kotlin.Boolean;kotlin.Boolean;kotlin.Boolean){}[0]
+    final fun getErrorString(androidx.compose.runtime/Composer?, kotlin/Int): kotlin/String? // com.chrisjenx.yakcov/ValueValidator.getErrorString|getErrorString(androidx.compose.runtime.Composer?;kotlin.Int){}[0]
+    final fun getValidationResultString(kotlin/Short, androidx.compose.runtime/Composer?, kotlin/Int, kotlin/Int): kotlin/String? // com.chrisjenx.yakcov/ValueValidator.getValidationResultString|getValidationResultString(kotlin.Short;androidx.compose.runtime.Composer?;kotlin.Int;kotlin.Int){}[0]
+    final fun isError(): kotlin/Boolean // com.chrisjenx.yakcov/ValueValidator.isError|isError(){}[0]
+    final fun outcome(): com.chrisjenx.yakcov/ValidationResult.Outcome? // com.chrisjenx.yakcov/ValueValidator.outcome|outcome(){}[0]
+    final fun supportingText(kotlin/Short, kotlin/String?, androidx.compose.runtime/Composer?, kotlin/Int, kotlin/Int): kotlin/Function2<androidx.compose.runtime/Composer, kotlin/Int, kotlin/Unit>? // com.chrisjenx.yakcov/ValueValidator.supportingText|supportingText(kotlin.Short;kotlin.String?;androidx.compose.runtime.Composer?;kotlin.Int;kotlin.Int){}[0]
+    open fun equals(kotlin/Any?): kotlin/Boolean // com.chrisjenx.yakcov/ValueValidator.equals|equals(kotlin.Any?){}[0]
+    open fun hashCode(): kotlin/Int // com.chrisjenx.yakcov/ValueValidator.hashCode|hashCode(){}[0]
+    open fun onValueChange(#A?) // com.chrisjenx.yakcov/ValueValidator.onValueChange|onValueChange(1:0?){}[0]
+    open fun reset() // com.chrisjenx.yakcov/ValueValidator.reset|reset(){}[0]
+    open fun toString(): kotlin/String // com.chrisjenx.yakcov/ValueValidator.toString|toString(){}[0]
+    open fun validate(#A? = ...): kotlin/Boolean // com.chrisjenx.yakcov/ValueValidator.validate|validate(1:0?){}[0]
+    open fun validateWithResult(#A? = ...): com.chrisjenx.yakcov/ValidationResult.Outcome // com.chrisjenx.yakcov/ValueValidator.validateWithResult|validateWithResult(1:0?){}[0]
+
+    final object Companion { // com.chrisjenx.yakcov/ValueValidator.Companion|null[0]
+        final var defaultValidationSeparator // com.chrisjenx.yakcov/ValueValidator.Companion.defaultValidationSeparator|{}defaultValidationSeparator[0]
+            final fun <get-defaultValidationSeparator>(): kotlin/String // com.chrisjenx.yakcov/ValueValidator.Companion.defaultValidationSeparator.<get-defaultValidationSeparator>|<get-defaultValidationSeparator>(){}[0]
+            final fun <set-defaultValidationSeparator>(kotlin/String) // com.chrisjenx.yakcov/ValueValidator.Companion.defaultValidationSeparator.<set-defaultValidationSeparator>|<set-defaultValidationSeparator>(kotlin.String){}[0]
+    }
+}
+
+final class <#A: kotlin.collections/List<*>?> com.chrisjenx.yakcov.generic/ListNotEmpty : com.chrisjenx.yakcov/ValueValidatorRule<#A> { // com.chrisjenx.yakcov.generic/ListNotEmpty|null[0]
+    constructor <init>() // com.chrisjenx.yakcov.generic/ListNotEmpty.<init>|<init>(){}[0]
+
+    final fun validate(#A): com.chrisjenx.yakcov/ValidationResult // com.chrisjenx.yakcov.generic/ListNotEmpty.validate|validate(1:0){}[0]
+}
+
+final class <#A: kotlin/Any?> com.chrisjenx.yakcov.generic/GenericValueValidator : com.chrisjenx.yakcov/ValueValidator<#A, #A> { // com.chrisjenx.yakcov.generic/GenericValueValidator|null[0]
+    constructor <init>(androidx.compose.runtime/MutableState<#A>, kotlin.collections/List<com.chrisjenx.yakcov/ValueValidatorRule<#A>>, kotlin/Boolean = ..., kotlin/Boolean = ..., kotlin/String = ...) // com.chrisjenx.yakcov.generic/GenericValueValidator.<init>|<init>(androidx.compose.runtime.MutableState<1:0>;kotlin.collections.List<com.chrisjenx.yakcov.ValueValidatorRule<1:0>>;kotlin.Boolean;kotlin.Boolean;kotlin.String){}[0]
+}
+
+final class <#A: kotlin/Any?> com.chrisjenx.yakcov.generic/InList : com.chrisjenx.yakcov/ValueValidatorRule<#A?> { // com.chrisjenx.yakcov.generic/InList|null[0]
+    constructor <init>(androidx.compose.runtime/State<kotlin.collections/List<#A>>) // com.chrisjenx.yakcov.generic/InList.<init>|<init>(androidx.compose.runtime.State<kotlin.collections.List<1:0>>){}[0]
+    constructor <init>(kotlin.collections/List<#A>) // com.chrisjenx.yakcov.generic/InList.<init>|<init>(kotlin.collections.List<1:0>){}[0]
+
+    final fun validate(#A?): com.chrisjenx.yakcov/ValidationResult // com.chrisjenx.yakcov.generic/InList.validate|validate(1:0?){}[0]
+}
+
+final class <#A: kotlin/Any?> com.chrisjenx.yakcov.generic/Required : com.chrisjenx.yakcov/ValueValidatorRule<#A?> { // com.chrisjenx.yakcov.generic/Required|null[0]
+    constructor <init>() // com.chrisjenx.yakcov.generic/Required.<init>|<init>(){}[0]
+
+    final fun validate(#A?): com.chrisjenx.yakcov/ValidationResult // com.chrisjenx.yakcov.generic/Required.validate|validate(1:0?){}[0]
+}
+
+final class <#A: kotlin/Any?> com.chrisjenx.yakcov/FieldValidator { // com.chrisjenx.yakcov/FieldValidator|null[0]
+    constructor <init>(#A, kotlin.collections/List<com.chrisjenx.yakcov/ValueValidatorRule<#A>>, kotlin/Boolean = ..., com.chrisjenx.yakcov/FieldValidatorObserver<#A>? = ...) // com.chrisjenx.yakcov/FieldValidator.<init>|<init>(1:0;kotlin.collections.List<com.chrisjenx.yakcov.ValueValidatorRule<1:0>>;kotlin.Boolean;com.chrisjenx.yakcov.FieldValidatorObserver<1:0>?){}[0]
+
+    final var attempts // com.chrisjenx.yakcov/FieldValidator.attempts|{}attempts[0]
+        final fun <get-attempts>(): kotlin/Int // com.chrisjenx.yakcov/FieldValidator.attempts.<get-attempts>|<get-attempts>(){}[0]
+    final var state // com.chrisjenx.yakcov/FieldValidator.state|{}state[0]
+        final fun <get-state>(): com.chrisjenx.yakcov/FieldValidationState // com.chrisjenx.yakcov/FieldValidator.state.<get-state>|<get-state>(){}[0]
+    final var value // com.chrisjenx.yakcov/FieldValidator.value|{}value[0]
+        final fun <get-value>(): #A // com.chrisjenx.yakcov/FieldValidator.value.<get-value>|<get-value>(){}[0]
+
+    final fun onFocusLost(): kotlin/Boolean // com.chrisjenx.yakcov/FieldValidator.onFocusLost|onFocusLost(){}[0]
+    final fun onValueChange(#A) // com.chrisjenx.yakcov/FieldValidator.onValueChange|onValueChange(1:0){}[0]
+    final fun reset(#A) // com.chrisjenx.yakcov/FieldValidator.reset|reset(1:0){}[0]
+    final fun reset() // com.chrisjenx.yakcov/FieldValidator.reset|reset(){}[0]
+    final fun validate(): kotlin/Boolean // com.chrisjenx.yakcov/FieldValidator.validate|validate(){}[0]
+}
+
+final class <#A: kotlin/Any?> com.chrisjenx.yakcov/Optional : com.chrisjenx.yakcov/ValueValidatorRule<#A> { // com.chrisjenx.yakcov/Optional|null[0]
+    constructor <init>(androidx.compose.runtime/State<kotlin/Boolean>, com.chrisjenx.yakcov/ValueValidatorRule<#A>) // com.chrisjenx.yakcov/Optional.<init>|<init>(androidx.compose.runtime.State<kotlin.Boolean>;com.chrisjenx.yakcov.ValueValidatorRule<1:0>){}[0]
+    constructor <init>(kotlin/Boolean, com.chrisjenx.yakcov/ValueValidatorRule<#A>) // com.chrisjenx.yakcov/Optional.<init>|<init>(kotlin.Boolean;com.chrisjenx.yakcov.ValueValidatorRule<1:0>){}[0]
+
+    final fun validate(#A): com.chrisjenx.yakcov/ValidationResult // com.chrisjenx.yakcov/Optional.validate|validate(1:0){}[0]
+}
+
+final class <#A: kotlin/Comparable<#A> & kotlin/Number> com.chrisjenx.yakcov.generic/InRange : com.chrisjenx.yakcov/ValueValidatorRule<#A?> { // com.chrisjenx.yakcov.generic/InRange|null[0]
+    constructor <init>(#A, #A) // com.chrisjenx.yakcov.generic/InRange.<init>|<init>(1:0;1:0){}[0]
+    constructor <init>(androidx.compose.runtime/State<#A>, androidx.compose.runtime/State<#A>) // com.chrisjenx.yakcov.generic/InRange.<init>|<init>(androidx.compose.runtime.State<1:0>;androidx.compose.runtime.State<1:0>){}[0]
+
+    final fun validate(#A?): com.chrisjenx.yakcov/ValidationResult // com.chrisjenx.yakcov.generic/InRange.validate|validate(1:0?){}[0]
+}
+
+final class <#A: kotlin/Comparable<#A> & kotlin/Number> com.chrisjenx.yakcov.generic/Max : com.chrisjenx.yakcov/ValueValidatorRule<#A?> { // com.chrisjenx.yakcov.generic/Max|null[0]
+    constructor <init>(#A) // com.chrisjenx.yakcov.generic/Max.<init>|<init>(1:0){}[0]
+    constructor <init>(androidx.compose.runtime/State<#A>) // com.chrisjenx.yakcov.generic/Max.<init>|<init>(androidx.compose.runtime.State<1:0>){}[0]
+
+    final fun validate(#A?): com.chrisjenx.yakcov/ValidationResult // com.chrisjenx.yakcov.generic/Max.validate|validate(1:0?){}[0]
+}
+
+final class <#A: kotlin/Comparable<#A> & kotlin/Number> com.chrisjenx.yakcov.generic/Min : com.chrisjenx.yakcov/ValueValidatorRule<#A?> { // com.chrisjenx.yakcov.generic/Min|null[0]
+    constructor <init>(#A) // com.chrisjenx.yakcov.generic/Min.<init>|<init>(1:0){}[0]
+    constructor <init>(androidx.compose.runtime/State<#A>) // com.chrisjenx.yakcov.generic/Min.<init>|<init>(androidx.compose.runtime.State<1:0>){}[0]
+
+    final fun validate(#A?): com.chrisjenx.yakcov/ValidationResult // com.chrisjenx.yakcov.generic/Min.validate|validate(1:0?){}[0]
+}
+
+final class com.chrisjenx.yakcov.strings/DayValidation : com.chrisjenx.yakcov/ValueValidatorRule<kotlin/String> { // com.chrisjenx.yakcov.strings/DayValidation|null[0]
+    constructor <init>(androidx.compose.runtime/State<kotlinx.datetime/LocalDate>) // com.chrisjenx.yakcov.strings/DayValidation.<init>|<init>(androidx.compose.runtime.State<kotlinx.datetime.LocalDate>){}[0]
+    constructor <init>(kotlinx.datetime/LocalDate) // com.chrisjenx.yakcov.strings/DayValidation.<init>|<init>(kotlinx.datetime.LocalDate){}[0]
+
+    final val localDate // com.chrisjenx.yakcov.strings/DayValidation.localDate|{}localDate[0]
+        final fun <get-localDate>(): androidx.compose.runtime/State<kotlinx.datetime/LocalDate> // com.chrisjenx.yakcov.strings/DayValidation.localDate.<get-localDate>|<get-localDate>(){}[0]
+
+    final fun component1(): androidx.compose.runtime/State<kotlinx.datetime/LocalDate> // com.chrisjenx.yakcov.strings/DayValidation.component1|component1(){}[0]
+    final fun copy(androidx.compose.runtime/State<kotlinx.datetime/LocalDate> = ...): com.chrisjenx.yakcov.strings/DayValidation // com.chrisjenx.yakcov.strings/DayValidation.copy|copy(androidx.compose.runtime.State<kotlinx.datetime.LocalDate>){}[0]
+    final fun equals(kotlin/Any?): kotlin/Boolean // com.chrisjenx.yakcov.strings/DayValidation.equals|equals(kotlin.Any?){}[0]
+    final fun hashCode(): kotlin/Int // com.chrisjenx.yakcov.strings/DayValidation.hashCode|hashCode(){}[0]
+    final fun toString(): kotlin/String // com.chrisjenx.yakcov.strings/DayValidation.toString|toString(){}[0]
+    final fun validate(kotlin/String): com.chrisjenx.yakcov/ValidationResult // com.chrisjenx.yakcov.strings/DayValidation.validate|validate(kotlin.String){}[0]
+}
+
+final class com.chrisjenx.yakcov.strings/MaxLength : com.chrisjenx.yakcov/ValueValidatorRule<kotlin/String> { // com.chrisjenx.yakcov.strings/MaxLength|null[0]
+    constructor <init>(androidx.compose.runtime/State<kotlin/Int>) // com.chrisjenx.yakcov.strings/MaxLength.<init>|<init>(androidx.compose.runtime.State<kotlin.Int>){}[0]
+    constructor <init>(kotlin/Int) // com.chrisjenx.yakcov.strings/MaxLength.<init>|<init>(kotlin.Int){}[0]
+
+    final val maxLength // com.chrisjenx.yakcov.strings/MaxLength.maxLength|{}maxLength[0]
+        final fun <get-maxLength>(): androidx.compose.runtime/State<kotlin/Int> // com.chrisjenx.yakcov.strings/MaxLength.maxLength.<get-maxLength>|<get-maxLength>(){}[0]
+
+    final fun component1(): androidx.compose.runtime/State<kotlin/Int> // com.chrisjenx.yakcov.strings/MaxLength.component1|component1(){}[0]
+    final fun copy(androidx.compose.runtime/State<kotlin/Int> = ...): com.chrisjenx.yakcov.strings/MaxLength // com.chrisjenx.yakcov.strings/MaxLength.copy|copy(androidx.compose.runtime.State<kotlin.Int>){}[0]
+    final fun equals(kotlin/Any?): kotlin/Boolean // com.chrisjenx.yakcov.strings/MaxLength.equals|equals(kotlin.Any?){}[0]
+    final fun hashCode(): kotlin/Int // com.chrisjenx.yakcov.strings/MaxLength.hashCode|hashCode(){}[0]
+    final fun toString(): kotlin/String // com.chrisjenx.yakcov.strings/MaxLength.toString|toString(){}[0]
+    final fun validate(kotlin/String): com.chrisjenx.yakcov/ValidationResult // com.chrisjenx.yakcov.strings/MaxLength.validate|validate(kotlin.String){}[0]
+}
+
+final class com.chrisjenx.yakcov.strings/MaxValue : com.chrisjenx.yakcov/ValueValidatorRule<kotlin/String> { // com.chrisjenx.yakcov.strings/MaxValue|null[0]
+    constructor <init>(androidx.compose.runtime/State<kotlin/Number>) // com.chrisjenx.yakcov.strings/MaxValue.<init>|<init>(androidx.compose.runtime.State<kotlin.Number>){}[0]
+    constructor <init>(kotlin/Number) // com.chrisjenx.yakcov.strings/MaxValue.<init>|<init>(kotlin.Number){}[0]
+
+    final val maxValue // com.chrisjenx.yakcov.strings/MaxValue.maxValue|{}maxValue[0]
+        final fun <get-maxValue>(): androidx.compose.runtime/State<kotlin/Number> // com.chrisjenx.yakcov.strings/MaxValue.maxValue.<get-maxValue>|<get-maxValue>(){}[0]
+
+    final fun component1(): androidx.compose.runtime/State<kotlin/Number> // com.chrisjenx.yakcov.strings/MaxValue.component1|component1(){}[0]
+    final fun copy(androidx.compose.runtime/State<kotlin/Number> = ...): com.chrisjenx.yakcov.strings/MaxValue // com.chrisjenx.yakcov.strings/MaxValue.copy|copy(androidx.compose.runtime.State<kotlin.Number>){}[0]
+    final fun equals(kotlin/Any?): kotlin/Boolean // com.chrisjenx.yakcov.strings/MaxValue.equals|equals(kotlin.Any?){}[0]
+    final fun hashCode(): kotlin/Int // com.chrisjenx.yakcov.strings/MaxValue.hashCode|hashCode(){}[0]
+    final fun toString(): kotlin/String // com.chrisjenx.yakcov.strings/MaxValue.toString|toString(){}[0]
+    final fun validate(kotlin/String): com.chrisjenx.yakcov/ValidationResult // com.chrisjenx.yakcov.strings/MaxValue.validate|validate(kotlin.String){}[0]
+}
+
+final class com.chrisjenx.yakcov.strings/MinLength : com.chrisjenx.yakcov/ValueValidatorRule<kotlin/String> { // com.chrisjenx.yakcov.strings/MinLength|null[0]
+    constructor <init>(androidx.compose.runtime/State<kotlin/Int>, androidx.compose.runtime/State<kotlin/Boolean> = ..., androidx.compose.runtime/State<kotlin/Boolean> = ...) // com.chrisjenx.yakcov.strings/MinLength.<init>|<init>(androidx.compose.runtime.State<kotlin.Int>;androidx.compose.runtime.State<kotlin.Boolean>;androidx.compose.runtime.State<kotlin.Boolean>){}[0]
+    constructor <init>(kotlin/Int, kotlin/Boolean = ..., kotlin/Boolean = ...) // com.chrisjenx.yakcov.strings/MinLength.<init>|<init>(kotlin.Int;kotlin.Boolean;kotlin.Boolean){}[0]
+
+    final val includeWhiteSpace // com.chrisjenx.yakcov.strings/MinLength.includeWhiteSpace|{}includeWhiteSpace[0]
+        final fun <get-includeWhiteSpace>(): androidx.compose.runtime/State<kotlin/Boolean> // com.chrisjenx.yakcov.strings/MinLength.includeWhiteSpace.<get-includeWhiteSpace>|<get-includeWhiteSpace>(){}[0]
+    final val minLength // com.chrisjenx.yakcov.strings/MinLength.minLength|{}minLength[0]
+        final fun <get-minLength>(): androidx.compose.runtime/State<kotlin/Int> // com.chrisjenx.yakcov.strings/MinLength.minLength.<get-minLength>|<get-minLength>(){}[0]
+    final val trim // com.chrisjenx.yakcov.strings/MinLength.trim|{}trim[0]
+        final fun <get-trim>(): androidx.compose.runtime/State<kotlin/Boolean> // com.chrisjenx.yakcov.strings/MinLength.trim.<get-trim>|<get-trim>(){}[0]
+
+    final fun component1(): androidx.compose.runtime/State<kotlin/Int> // com.chrisjenx.yakcov.strings/MinLength.component1|component1(){}[0]
+    final fun component2(): androidx.compose.runtime/State<kotlin/Boolean> // com.chrisjenx.yakcov.strings/MinLength.component2|component2(){}[0]
+    final fun component3(): androidx.compose.runtime/State<kotlin/Boolean> // com.chrisjenx.yakcov.strings/MinLength.component3|component3(){}[0]
+    final fun copy(androidx.compose.runtime/State<kotlin/Int> = ..., androidx.compose.runtime/State<kotlin/Boolean> = ..., androidx.compose.runtime/State<kotlin/Boolean> = ...): com.chrisjenx.yakcov.strings/MinLength // com.chrisjenx.yakcov.strings/MinLength.copy|copy(androidx.compose.runtime.State<kotlin.Int>;androidx.compose.runtime.State<kotlin.Boolean>;androidx.compose.runtime.State<kotlin.Boolean>){}[0]
+    final fun equals(kotlin/Any?): kotlin/Boolean // com.chrisjenx.yakcov.strings/MinLength.equals|equals(kotlin.Any?){}[0]
+    final fun hashCode(): kotlin/Int // com.chrisjenx.yakcov.strings/MinLength.hashCode|hashCode(){}[0]
+    final fun toString(): kotlin/String // com.chrisjenx.yakcov.strings/MinLength.toString|toString(){}[0]
+    final fun validate(kotlin/String): com.chrisjenx.yakcov/ValidationResult // com.chrisjenx.yakcov.strings/MinLength.validate|validate(kotlin.String){}[0]
+}
+
+final class com.chrisjenx.yakcov.strings/MinValue : com.chrisjenx.yakcov/ValueValidatorRule<kotlin/String> { // com.chrisjenx.yakcov.strings/MinValue|null[0]
+    constructor <init>(androidx.compose.runtime/State<kotlin/Number>) // com.chrisjenx.yakcov.strings/MinValue.<init>|<init>(androidx.compose.runtime.State<kotlin.Number>){}[0]
+    constructor <init>(kotlin/Number) // com.chrisjenx.yakcov.strings/MinValue.<init>|<init>(kotlin.Number){}[0]
+
+    final val minValue // com.chrisjenx.yakcov.strings/MinValue.minValue|{}minValue[0]
+        final fun <get-minValue>(): androidx.compose.runtime/State<kotlin/Number> // com.chrisjenx.yakcov.strings/MinValue.minValue.<get-minValue>|<get-minValue>(){}[0]
+
+    final fun component1(): androidx.compose.runtime/State<kotlin/Number> // com.chrisjenx.yakcov.strings/MinValue.component1|component1(){}[0]
+    final fun copy(androidx.compose.runtime/State<kotlin/Number> = ...): com.chrisjenx.yakcov.strings/MinValue // com.chrisjenx.yakcov.strings/MinValue.copy|copy(androidx.compose.runtime.State<kotlin.Number>){}[0]
+    final fun equals(kotlin/Any?): kotlin/Boolean // com.chrisjenx.yakcov.strings/MinValue.equals|equals(kotlin.Any?){}[0]
+    final fun hashCode(): kotlin/Int // com.chrisjenx.yakcov.strings/MinValue.hashCode|hashCode(){}[0]
+    final fun toString(): kotlin/String // com.chrisjenx.yakcov.strings/MinValue.toString|toString(){}[0]
+    final fun validate(kotlin/String): com.chrisjenx.yakcov/ValidationResult // com.chrisjenx.yakcov.strings/MinValue.validate|validate(kotlin.String){}[0]
+}
+
+final class com.chrisjenx.yakcov.strings/MonthValidation : com.chrisjenx.yakcov/ValueValidatorRule<kotlin/String> { // com.chrisjenx.yakcov.strings/MonthValidation|null[0]
+    constructor <init>(androidx.compose.runtime/State<kotlinx.datetime/LocalDate>) // com.chrisjenx.yakcov.strings/MonthValidation.<init>|<init>(androidx.compose.runtime.State<kotlinx.datetime.LocalDate>){}[0]
+    constructor <init>(kotlinx.datetime/LocalDate) // com.chrisjenx.yakcov.strings/MonthValidation.<init>|<init>(kotlinx.datetime.LocalDate){}[0]
+
+    final val localDate // com.chrisjenx.yakcov.strings/MonthValidation.localDate|{}localDate[0]
+        final fun <get-localDate>(): androidx.compose.runtime/State<kotlinx.datetime/LocalDate> // com.chrisjenx.yakcov.strings/MonthValidation.localDate.<get-localDate>|<get-localDate>(){}[0]
+
+    final fun component1(): androidx.compose.runtime/State<kotlinx.datetime/LocalDate> // com.chrisjenx.yakcov.strings/MonthValidation.component1|component1(){}[0]
+    final fun copy(androidx.compose.runtime/State<kotlinx.datetime/LocalDate> = ...): com.chrisjenx.yakcov.strings/MonthValidation // com.chrisjenx.yakcov.strings/MonthValidation.copy|copy(androidx.compose.runtime.State<kotlinx.datetime.LocalDate>){}[0]
+    final fun equals(kotlin/Any?): kotlin/Boolean // com.chrisjenx.yakcov.strings/MonthValidation.equals|equals(kotlin.Any?){}[0]
+    final fun hashCode(): kotlin/Int // com.chrisjenx.yakcov.strings/MonthValidation.hashCode|hashCode(){}[0]
+    final fun toString(): kotlin/String // com.chrisjenx.yakcov.strings/MonthValidation.toString|toString(){}[0]
+    final fun validate(kotlin/String): com.chrisjenx.yakcov/ValidationResult // com.chrisjenx.yakcov.strings/MonthValidation.validate|validate(kotlin.String){}[0]
+}
+
+final class com.chrisjenx.yakcov.strings/OneOf : com.chrisjenx.yakcov/ValueValidatorRule<kotlin/String> { // com.chrisjenx.yakcov.strings/OneOf|null[0]
+    constructor <init>(androidx.compose.runtime/State<kotlin.collections/Set<kotlin/String>>, kotlin/Boolean = ..., kotlin/Boolean = ...) // com.chrisjenx.yakcov.strings/OneOf.<init>|<init>(androidx.compose.runtime.State<kotlin.collections.Set<kotlin.String>>;kotlin.Boolean;kotlin.Boolean){}[0]
+    constructor <init>(kotlin.collections/Set<kotlin/String>, kotlin/Boolean = ..., kotlin/Boolean = ...) // com.chrisjenx.yakcov.strings/OneOf.<init>|<init>(kotlin.collections.Set<kotlin.String>;kotlin.Boolean;kotlin.Boolean){}[0]
+
+    final val allowed // com.chrisjenx.yakcov.strings/OneOf.allowed|{}allowed[0]
+        final fun <get-allowed>(): androidx.compose.runtime/State<kotlin.collections/Set<kotlin/String>> // com.chrisjenx.yakcov.strings/OneOf.allowed.<get-allowed>|<get-allowed>(){}[0]
+    final val ignoreCase // com.chrisjenx.yakcov.strings/OneOf.ignoreCase|{}ignoreCase[0]
+        final fun <get-ignoreCase>(): kotlin/Boolean // com.chrisjenx.yakcov.strings/OneOf.ignoreCase.<get-ignoreCase>|<get-ignoreCase>(){}[0]
+    final val trim // com.chrisjenx.yakcov.strings/OneOf.trim|{}trim[0]
+        final fun <get-trim>(): kotlin/Boolean // com.chrisjenx.yakcov.strings/OneOf.trim.<get-trim>|<get-trim>(){}[0]
+
+    final fun component1(): androidx.compose.runtime/State<kotlin.collections/Set<kotlin/String>> // com.chrisjenx.yakcov.strings/OneOf.component1|component1(){}[0]
+    final fun component2(): kotlin/Boolean // com.chrisjenx.yakcov.strings/OneOf.component2|component2(){}[0]
+    final fun component3(): kotlin/Boolean // com.chrisjenx.yakcov.strings/OneOf.component3|component3(){}[0]
+    final fun copy(androidx.compose.runtime/State<kotlin.collections/Set<kotlin/String>> = ..., kotlin/Boolean = ..., kotlin/Boolean = ...): com.chrisjenx.yakcov.strings/OneOf // com.chrisjenx.yakcov.strings/OneOf.copy|copy(androidx.compose.runtime.State<kotlin.collections.Set<kotlin.String>>;kotlin.Boolean;kotlin.Boolean){}[0]
+    final fun equals(kotlin/Any?): kotlin/Boolean // com.chrisjenx.yakcov.strings/OneOf.equals|equals(kotlin.Any?){}[0]
+    final fun hashCode(): kotlin/Int // com.chrisjenx.yakcov.strings/OneOf.hashCode|hashCode(){}[0]
+    final fun toString(): kotlin/String // com.chrisjenx.yakcov.strings/OneOf.toString|toString(){}[0]
+    final fun validate(kotlin/String): com.chrisjenx.yakcov/ValidationResult // com.chrisjenx.yakcov.strings/OneOf.validate|validate(kotlin.String){}[0]
+}
+
+final class com.chrisjenx.yakcov.strings/Phone : com.chrisjenx.yakcov/ValueValidatorRule<kotlin/String> { // com.chrisjenx.yakcov.strings/Phone|null[0]
+    constructor <init>(androidx.compose.runtime/State<kotlin/String> = ...) // com.chrisjenx.yakcov.strings/Phone.<init>|<init>(androidx.compose.runtime.State<kotlin.String>){}[0]
+    constructor <init>(kotlin/String) // com.chrisjenx.yakcov.strings/Phone.<init>|<init>(kotlin.String){}[0]
+
+    final val defaultRegion // com.chrisjenx.yakcov.strings/Phone.defaultRegion|{}defaultRegion[0]
+        final fun <get-defaultRegion>(): androidx.compose.runtime/State<kotlin/String> // com.chrisjenx.yakcov.strings/Phone.defaultRegion.<get-defaultRegion>|<get-defaultRegion>(){}[0]
+
+    final fun component1(): androidx.compose.runtime/State<kotlin/String> // com.chrisjenx.yakcov.strings/Phone.component1|component1(){}[0]
+    final fun copy(androidx.compose.runtime/State<kotlin/String> = ...): com.chrisjenx.yakcov.strings/Phone // com.chrisjenx.yakcov.strings/Phone.copy|copy(androidx.compose.runtime.State<kotlin.String>){}[0]
+    final fun equals(kotlin/Any?): kotlin/Boolean // com.chrisjenx.yakcov.strings/Phone.equals|equals(kotlin.Any?){}[0]
+    final fun hashCode(): kotlin/Int // com.chrisjenx.yakcov.strings/Phone.hashCode|hashCode(){}[0]
+    final fun toString(): kotlin/String // com.chrisjenx.yakcov.strings/Phone.toString|toString(){}[0]
+    final fun validate(kotlin/String): com.chrisjenx.yakcov/ValidationResult // com.chrisjenx.yakcov.strings/Phone.validate|validate(kotlin.String){}[0]
+}
+
+final class com.chrisjenx.yakcov.strings/TextFieldValueValidator : com.chrisjenx.yakcov/ValueValidator<androidx.compose.ui.text.input/TextFieldValue, kotlin/String> { // com.chrisjenx.yakcov.strings/TextFieldValueValidator|null[0]
+    constructor <init>(androidx.compose.runtime/MutableState<androidx.compose.ui.text.input/TextFieldValue> = ..., kotlin.collections/List<com.chrisjenx.yakcov/ValueValidatorRule<kotlin/String>> = ..., kotlin/Boolean = ..., kotlin/Boolean = ..., kotlin/String = ...) // com.chrisjenx.yakcov.strings/TextFieldValueValidator.<init>|<init>(androidx.compose.runtime.MutableState<androidx.compose.ui.text.input.TextFieldValue>;kotlin.collections.List<com.chrisjenx.yakcov.ValueValidatorRule<kotlin.String>>;kotlin.Boolean;kotlin.Boolean;kotlin.String){}[0]
+    constructor <init>(kotlin/String, kotlin.collections/List<com.chrisjenx.yakcov/ValueValidatorRule<kotlin/String>> = ..., kotlin/Boolean = ..., kotlin/Boolean = ..., kotlin/String = ...) // com.chrisjenx.yakcov.strings/TextFieldValueValidator.<init>|<init>(kotlin.String;kotlin.collections.List<com.chrisjenx.yakcov.ValueValidatorRule<kotlin.String>>;kotlin.Boolean;kotlin.Boolean;kotlin.String){}[0]
+
+    final fun (androidx.compose.ui/Modifier).onFocusCursorToEnd(kotlinx.coroutines/CoroutineScope?, kotlin/Boolean, androidx.compose.runtime/Composer?, kotlin/Int, kotlin/Int): androidx.compose.ui/Modifier // com.chrisjenx.yakcov.strings/TextFieldValueValidator.onFocusCursorToEnd|onFocusCursorToEnd@androidx.compose.ui.Modifier(kotlinx.coroutines.CoroutineScope?;kotlin.Boolean;androidx.compose.runtime.Composer?;kotlin.Int;kotlin.Int){}[0]
+    final fun onValueChange(kotlin/String) // com.chrisjenx.yakcov.strings/TextFieldValueValidator.onValueChange|onValueChange(kotlin.String){}[0]
+    final fun toString(): kotlin/String // com.chrisjenx.yakcov.strings/TextFieldValueValidator.toString|toString(){}[0]
+    final fun validate(kotlin/String? = ...): kotlin/Boolean // com.chrisjenx.yakcov.strings/TextFieldValueValidator.validate|validate(kotlin.String?){}[0]
+}
+
+final class com.chrisjenx.yakcov.strings/YearValidation : com.chrisjenx.yakcov/ValueValidatorRule<kotlin/String> { // com.chrisjenx.yakcov.strings/YearValidation|null[0]
+    constructor <init>(androidx.compose.runtime/State<kotlinx.datetime/LocalDate>) // com.chrisjenx.yakcov.strings/YearValidation.<init>|<init>(androidx.compose.runtime.State<kotlinx.datetime.LocalDate>){}[0]
+    constructor <init>(kotlinx.datetime/LocalDate) // com.chrisjenx.yakcov.strings/YearValidation.<init>|<init>(kotlinx.datetime.LocalDate){}[0]
+
+    final val localDate // com.chrisjenx.yakcov.strings/YearValidation.localDate|{}localDate[0]
+        final fun <get-localDate>(): androidx.compose.runtime/State<kotlinx.datetime/LocalDate> // com.chrisjenx.yakcov.strings/YearValidation.localDate.<get-localDate>|<get-localDate>(){}[0]
+
+    final fun component1(): androidx.compose.runtime/State<kotlinx.datetime/LocalDate> // com.chrisjenx.yakcov.strings/YearValidation.component1|component1(){}[0]
+    final fun copy(androidx.compose.runtime/State<kotlinx.datetime/LocalDate> = ...): com.chrisjenx.yakcov.strings/YearValidation // com.chrisjenx.yakcov.strings/YearValidation.copy|copy(androidx.compose.runtime.State<kotlinx.datetime.LocalDate>){}[0]
+    final fun equals(kotlin/Any?): kotlin/Boolean // com.chrisjenx.yakcov.strings/YearValidation.equals|equals(kotlin.Any?){}[0]
+    final fun hashCode(): kotlin/Int // com.chrisjenx.yakcov.strings/YearValidation.hashCode|hashCode(){}[0]
+    final fun toString(): kotlin/String // com.chrisjenx.yakcov.strings/YearValidation.toString|toString(){}[0]
+    final fun validate(kotlin/String): com.chrisjenx.yakcov/ValidationResult // com.chrisjenx.yakcov.strings/YearValidation.validate|validate(kotlin.String){}[0]
+}
+
+final class com.chrisjenx.yakcov/FieldValidationState { // com.chrisjenx.yakcov/FieldValidationState|null[0]
+    constructor <init>(com.chrisjenx.yakcov/ValidationResult.Outcome = ..., kotlin/Boolean = ..., com.chrisjenx.yakcov/ValidationResult? = ...) // com.chrisjenx.yakcov/FieldValidationState.<init>|<init>(com.chrisjenx.yakcov.ValidationResult.Outcome;kotlin.Boolean;com.chrisjenx.yakcov.ValidationResult?){}[0]
+
+    final val isError // com.chrisjenx.yakcov/FieldValidationState.isError|{}isError[0]
+        final fun <get-isError>(): kotlin/Boolean // com.chrisjenx.yakcov/FieldValidationState.isError.<get-isError>|<get-isError>(){}[0]
+    final val isWarning // com.chrisjenx.yakcov/FieldValidationState.isWarning|{}isWarning[0]
+        final fun <get-isWarning>(): kotlin/Boolean // com.chrisjenx.yakcov/FieldValidationState.isWarning.<get-isWarning>|<get-isWarning>(){}[0]
+    final val result // com.chrisjenx.yakcov/FieldValidationState.result|{}result[0]
+        final fun <get-result>(): com.chrisjenx.yakcov/ValidationResult? // com.chrisjenx.yakcov/FieldValidationState.result.<get-result>|<get-result>(){}[0]
+    final val severity // com.chrisjenx.yakcov/FieldValidationState.severity|{}severity[0]
+        final fun <get-severity>(): com.chrisjenx.yakcov/ValidationResult.Outcome // com.chrisjenx.yakcov/FieldValidationState.severity.<get-severity>|<get-severity>(){}[0]
+    final val showError // com.chrisjenx.yakcov/FieldValidationState.showError|{}showError[0]
+        final fun <get-showError>(): kotlin/Boolean // com.chrisjenx.yakcov/FieldValidationState.showError.<get-showError>|<get-showError>(){}[0]
+
+    final fun component1(): com.chrisjenx.yakcov/ValidationResult.Outcome // com.chrisjenx.yakcov/FieldValidationState.component1|component1(){}[0]
+    final fun component2(): kotlin/Boolean // com.chrisjenx.yakcov/FieldValidationState.component2|component2(){}[0]
+    final fun component3(): com.chrisjenx.yakcov/ValidationResult? // com.chrisjenx.yakcov/FieldValidationState.component3|component3(){}[0]
+    final fun copy(com.chrisjenx.yakcov/ValidationResult.Outcome = ..., kotlin/Boolean = ..., com.chrisjenx.yakcov/ValidationResult? = ...): com.chrisjenx.yakcov/FieldValidationState // com.chrisjenx.yakcov/FieldValidationState.copy|copy(com.chrisjenx.yakcov.ValidationResult.Outcome;kotlin.Boolean;com.chrisjenx.yakcov.ValidationResult?){}[0]
+    final fun equals(kotlin/Any?): kotlin/Boolean // com.chrisjenx.yakcov/FieldValidationState.equals|equals(kotlin.Any?){}[0]
+    final fun hashCode(): kotlin/Int // com.chrisjenx.yakcov/FieldValidationState.hashCode|hashCode(){}[0]
+    final fun toString(): kotlin/String // com.chrisjenx.yakcov/FieldValidationState.toString|toString(){}[0]
+
+    final object $serializer : kotlinx.serialization.internal/GeneratedSerializer<com.chrisjenx.yakcov/FieldValidationState> { // com.chrisjenx.yakcov/FieldValidationState.$serializer|null[0]
+        final val descriptor // com.chrisjenx.yakcov/FieldValidationState.$serializer.descriptor|{}descriptor[0]
+            final fun <get-descriptor>(): kotlinx.serialization.descriptors/SerialDescriptor // com.chrisjenx.yakcov/FieldValidationState.$serializer.descriptor.<get-descriptor>|<get-descriptor>(){}[0]
+
+        final fun childSerializers(): kotlin/Array<kotlinx.serialization/KSerializer<*>> // com.chrisjenx.yakcov/FieldValidationState.$serializer.childSerializers|childSerializers(){}[0]
+        final fun deserialize(kotlinx.serialization.encoding/Decoder): com.chrisjenx.yakcov/FieldValidationState // com.chrisjenx.yakcov/FieldValidationState.$serializer.deserialize|deserialize(kotlinx.serialization.encoding.Decoder){}[0]
+        final fun serialize(kotlinx.serialization.encoding/Encoder, com.chrisjenx.yakcov/FieldValidationState) // com.chrisjenx.yakcov/FieldValidationState.$serializer.serialize|serialize(kotlinx.serialization.encoding.Encoder;com.chrisjenx.yakcov.FieldValidationState){}[0]
+    }
+
+    final object Companion { // com.chrisjenx.yakcov/FieldValidationState.Companion|null[0]
+        final val $childSerializers // com.chrisjenx.yakcov/FieldValidationState.Companion.$childSerializers|{}$childSerializers[0]
+        final val Pristine // com.chrisjenx.yakcov/FieldValidationState.Companion.Pristine|{}Pristine[0]
+            final fun <get-Pristine>(): com.chrisjenx.yakcov/FieldValidationState // com.chrisjenx.yakcov/FieldValidationState.Companion.Pristine.<get-Pristine>|<get-Pristine>(){}[0]
+        final val Saver // com.chrisjenx.yakcov/FieldValidationState.Companion.Saver|{}Saver[0]
+            final fun <get-Saver>(): androidx.compose.runtime.saveable/Saver<com.chrisjenx.yakcov/FieldValidationState, kotlin/Any> // com.chrisjenx.yakcov/FieldValidationState.Companion.Saver.<get-Saver>|<get-Saver>(){}[0]
+
+        final fun serializer(): kotlinx.serialization/KSerializer<com.chrisjenx.yakcov/FieldValidationState> // com.chrisjenx.yakcov/FieldValidationState.Companion.serializer|serializer(){}[0]
+    }
+}
+
+final class com.chrisjenx.yakcov/RegularValidationResult : com.chrisjenx.yakcov/ValidationResult { // com.chrisjenx.yakcov/RegularValidationResult|null[0]
+    final fun copy(kotlin/String? = ..., com.chrisjenx.yakcov/ValidationResult.Outcome = ...): com.chrisjenx.yakcov/RegularValidationResult // com.chrisjenx.yakcov/RegularValidationResult.copy|copy(kotlin.String?;com.chrisjenx.yakcov.ValidationResult.Outcome){}[0]
+    final fun equals(kotlin/Any?): kotlin/Boolean // com.chrisjenx.yakcov/RegularValidationResult.equals|equals(kotlin.Any?){}[0]
+    final fun format(androidx.compose.runtime/Composer?, kotlin/Int): kotlin/String? // com.chrisjenx.yakcov/RegularValidationResult.format|format(androidx.compose.runtime.Composer?;kotlin.Int){}[0]
+    final fun hashCode(): kotlin/Int // com.chrisjenx.yakcov/RegularValidationResult.hashCode|hashCode(){}[0]
+    final fun messageOrNull(): kotlin/String? // com.chrisjenx.yakcov/RegularValidationResult.messageOrNull|messageOrNull(){}[0]
+    final fun outcome(): com.chrisjenx.yakcov/ValidationResult.Outcome // com.chrisjenx.yakcov/RegularValidationResult.outcome|outcome(){}[0]
+    final fun toString(): kotlin/String // com.chrisjenx.yakcov/RegularValidationResult.toString|toString(){}[0]
+
+    final object Companion { // com.chrisjenx.yakcov/RegularValidationResult.Companion|null[0]
+        final fun error(kotlin/String): com.chrisjenx.yakcov/RegularValidationResult // com.chrisjenx.yakcov/RegularValidationResult.Companion.error|error(kotlin.String){}[0]
+        final fun info(kotlin/String): com.chrisjenx.yakcov/RegularValidationResult // com.chrisjenx.yakcov/RegularValidationResult.Companion.info|info(kotlin.String){}[0]
+        final fun success(kotlin/String? = ...): com.chrisjenx.yakcov/RegularValidationResult // com.chrisjenx.yakcov/RegularValidationResult.Companion.success|success(kotlin.String?){}[0]
+        final fun warning(kotlin/String): com.chrisjenx.yakcov/RegularValidationResult // com.chrisjenx.yakcov/RegularValidationResult.Companion.warning|warning(kotlin.String){}[0]
+    }
+}
+
+final class com.chrisjenx.yakcov/ResourceValidationResult : com.chrisjenx.yakcov/ValidationResult { // com.chrisjenx.yakcov/ResourceValidationResult|null[0]
+    final fun copy(org.jetbrains.compose.resources/StringResource? = ..., kotlin.collections/List<kotlin/Any> = ..., com.chrisjenx.yakcov/ValidationResult.Outcome = ...): com.chrisjenx.yakcov/ResourceValidationResult // com.chrisjenx.yakcov/ResourceValidationResult.copy|copy(org.jetbrains.compose.resources.StringResource?;kotlin.collections.List<kotlin.Any>;com.chrisjenx.yakcov.ValidationResult.Outcome){}[0]
+    final fun equals(kotlin/Any?): kotlin/Boolean // com.chrisjenx.yakcov/ResourceValidationResult.equals|equals(kotlin.Any?){}[0]
+    final fun format(androidx.compose.runtime/Composer?, kotlin/Int): kotlin/String? // com.chrisjenx.yakcov/ResourceValidationResult.format|format(androidx.compose.runtime.Composer?;kotlin.Int){}[0]
+    final fun hashCode(): kotlin/Int // com.chrisjenx.yakcov/ResourceValidationResult.hashCode|hashCode(){}[0]
+    final fun outcome(): com.chrisjenx.yakcov/ValidationResult.Outcome // com.chrisjenx.yakcov/ResourceValidationResult.outcome|outcome(){}[0]
+    final fun toString(): kotlin/String // com.chrisjenx.yakcov/ResourceValidationResult.toString|toString(){}[0]
+
+    final object Companion { // com.chrisjenx.yakcov/ResourceValidationResult.Companion|null[0]
+        final fun error(org.jetbrains.compose.resources/StringResource, kotlin/Array<out kotlin/Any>...): com.chrisjenx.yakcov/ResourceValidationResult // com.chrisjenx.yakcov/ResourceValidationResult.Companion.error|error(org.jetbrains.compose.resources.StringResource;kotlin.Array<out|kotlin.Any>...){}[0]
+        final fun info(org.jetbrains.compose.resources/StringResource, kotlin/Array<out kotlin/Any>...): com.chrisjenx.yakcov/ResourceValidationResult // com.chrisjenx.yakcov/ResourceValidationResult.Companion.info|info(org.jetbrains.compose.resources.StringResource;kotlin.Array<out|kotlin.Any>...){}[0]
+        final fun success(org.jetbrains.compose.resources/StringResource? = ..., kotlin/Array<out kotlin/Any>...): com.chrisjenx.yakcov/ResourceValidationResult // com.chrisjenx.yakcov/ResourceValidationResult.Companion.success|success(org.jetbrains.compose.resources.StringResource?;kotlin.Array<out|kotlin.Any>...){}[0]
+        final fun warning(org.jetbrains.compose.resources/StringResource, kotlin/Array<out kotlin/Any>...): com.chrisjenx.yakcov/ResourceValidationResult // com.chrisjenx.yakcov/ResourceValidationResult.Companion.warning|warning(org.jetbrains.compose.resources.StringResource;kotlin.Array<out|kotlin.Any>...){}[0]
+    }
+}
+
+final class com.chrisjenx.yakcov/ShakingState { // com.chrisjenx.yakcov/ShakingState|null[0]
+    constructor <init>(com.chrisjenx.yakcov/ShakingState.Strength, com.chrisjenx.yakcov/ShakingState.Direction) // com.chrisjenx.yakcov/ShakingState.<init>|<init>(com.chrisjenx.yakcov.ShakingState.Strength;com.chrisjenx.yakcov.ShakingState.Direction){}[0]
+
+    final val xPosition // com.chrisjenx.yakcov/ShakingState.xPosition|{}xPosition[0]
+        final fun <get-xPosition>(): androidx.compose.animation.core/Animatable<kotlin/Float, androidx.compose.animation.core/AnimationVector1D> // com.chrisjenx.yakcov/ShakingState.xPosition.<get-xPosition>|<get-xPosition>(){}[0]
+
+    final suspend fun shake(kotlin/Int = ...) // com.chrisjenx.yakcov/ShakingState.shake|shake(kotlin.Int){}[0]
+
+    final enum class Direction : kotlin/Enum<com.chrisjenx.yakcov/ShakingState.Direction> { // com.chrisjenx.yakcov/ShakingState.Direction|null[0]
+        enum entry LEFT // com.chrisjenx.yakcov/ShakingState.Direction.LEFT|null[0]
+        enum entry LEFT_THEN_RIGHT // com.chrisjenx.yakcov/ShakingState.Direction.LEFT_THEN_RIGHT|null[0]
+        enum entry RIGHT // com.chrisjenx.yakcov/ShakingState.Direction.RIGHT|null[0]
+        enum entry RIGHT_THEN_LEFT // com.chrisjenx.yakcov/ShakingState.Direction.RIGHT_THEN_LEFT|null[0]
+
+        final val entries // com.chrisjenx.yakcov/ShakingState.Direction.entries|#static{}entries[0]
+            final fun <get-entries>(): kotlin.enums/EnumEntries<com.chrisjenx.yakcov/ShakingState.Direction> // com.chrisjenx.yakcov/ShakingState.Direction.entries.<get-entries>|<get-entries>#static(){}[0]
+
+        final fun valueOf(kotlin/String): com.chrisjenx.yakcov/ShakingState.Direction // com.chrisjenx.yakcov/ShakingState.Direction.valueOf|valueOf#static(kotlin.String){}[0]
+        final fun values(): kotlin/Array<com.chrisjenx.yakcov/ShakingState.Direction> // com.chrisjenx.yakcov/ShakingState.Direction.values|values#static(){}[0]
+    }
+
+    sealed class Strength { // com.chrisjenx.yakcov/ShakingState.Strength|null[0]
+        final val value // com.chrisjenx.yakcov/ShakingState.Strength.value|{}value[0]
+            final fun <get-value>(): kotlin/Float // com.chrisjenx.yakcov/ShakingState.Strength.value.<get-value>|<get-value>(){}[0]
+
+        final class Custom : com.chrisjenx.yakcov/ShakingState.Strength { // com.chrisjenx.yakcov/ShakingState.Strength.Custom|null[0]
+            constructor <init>(kotlin/Float) // com.chrisjenx.yakcov/ShakingState.Strength.Custom.<init>|<init>(kotlin.Float){}[0]
+
+            final val strength // com.chrisjenx.yakcov/ShakingState.Strength.Custom.strength|{}strength[0]
+                final fun <get-strength>(): kotlin/Float // com.chrisjenx.yakcov/ShakingState.Strength.Custom.strength.<get-strength>|<get-strength>(){}[0]
+
+            final fun component1(): kotlin/Float // com.chrisjenx.yakcov/ShakingState.Strength.Custom.component1|component1(){}[0]
+            final fun copy(kotlin/Float = ...): com.chrisjenx.yakcov/ShakingState.Strength.Custom // com.chrisjenx.yakcov/ShakingState.Strength.Custom.copy|copy(kotlin.Float){}[0]
+            final fun equals(kotlin/Any?): kotlin/Boolean // com.chrisjenx.yakcov/ShakingState.Strength.Custom.equals|equals(kotlin.Any?){}[0]
+            final fun hashCode(): kotlin/Int // com.chrisjenx.yakcov/ShakingState.Strength.Custom.hashCode|hashCode(){}[0]
+            final fun toString(): kotlin/String // com.chrisjenx.yakcov/ShakingState.Strength.Custom.toString|toString(){}[0]
+        }
+
+        final object Normal : com.chrisjenx.yakcov/ShakingState.Strength { // com.chrisjenx.yakcov/ShakingState.Strength.Normal|null[0]
+            final fun equals(kotlin/Any?): kotlin/Boolean // com.chrisjenx.yakcov/ShakingState.Strength.Normal.equals|equals(kotlin.Any?){}[0]
+            final fun hashCode(): kotlin/Int // com.chrisjenx.yakcov/ShakingState.Strength.Normal.hashCode|hashCode(){}[0]
+            final fun toString(): kotlin/String // com.chrisjenx.yakcov/ShakingState.Strength.Normal.toString|toString(){}[0]
+        }
+
+        final object Strong : com.chrisjenx.yakcov/ShakingState.Strength { // com.chrisjenx.yakcov/ShakingState.Strength.Strong|null[0]
+            final fun equals(kotlin/Any?): kotlin/Boolean // com.chrisjenx.yakcov/ShakingState.Strength.Strong.equals|equals(kotlin.Any?){}[0]
+            final fun hashCode(): kotlin/Int // com.chrisjenx.yakcov/ShakingState.Strength.Strong.hashCode|hashCode(){}[0]
+            final fun toString(): kotlin/String // com.chrisjenx.yakcov/ShakingState.Strength.Strong.toString|toString(){}[0]
+        }
+    }
+}
+
+final object com.chrisjenx.yakcov.generic/IsChecked : com.chrisjenx.yakcov/ValueValidatorRule<kotlin/Boolean?> { // com.chrisjenx.yakcov.generic/IsChecked|null[0]
+    final fun equals(kotlin/Any?): kotlin/Boolean // com.chrisjenx.yakcov.generic/IsChecked.equals|equals(kotlin.Any?){}[0]
+    final fun hashCode(): kotlin/Int // com.chrisjenx.yakcov.generic/IsChecked.hashCode|hashCode(){}[0]
+    final fun toString(): kotlin/String // com.chrisjenx.yakcov.generic/IsChecked.toString|toString(){}[0]
+    final fun validate(kotlin/Boolean?): com.chrisjenx.yakcov/ValidationResult // com.chrisjenx.yakcov.generic/IsChecked.validate|validate(kotlin.Boolean?){}[0]
+}
+
+final object com.chrisjenx.yakcov.generic/IsNotChecked : com.chrisjenx.yakcov/ValueValidatorRule<kotlin/Boolean?> { // com.chrisjenx.yakcov.generic/IsNotChecked|null[0]
+    final fun equals(kotlin/Any?): kotlin/Boolean // com.chrisjenx.yakcov.generic/IsNotChecked.equals|equals(kotlin.Any?){}[0]
+    final fun hashCode(): kotlin/Int // com.chrisjenx.yakcov.generic/IsNotChecked.hashCode|hashCode(){}[0]
+    final fun toString(): kotlin/String // com.chrisjenx.yakcov.generic/IsNotChecked.toString|toString(){}[0]
+    final fun validate(kotlin/Boolean?): com.chrisjenx.yakcov/ValidationResult // com.chrisjenx.yakcov.generic/IsNotChecked.validate|validate(kotlin.Boolean?){}[0]
+}
+
+final object com.chrisjenx.yakcov.strings/Decimal : com.chrisjenx.yakcov/ValueValidatorRule<kotlin/String> { // com.chrisjenx.yakcov.strings/Decimal|null[0]
+    final fun equals(kotlin/Any?): kotlin/Boolean // com.chrisjenx.yakcov.strings/Decimal.equals|equals(kotlin.Any?){}[0]
+    final fun hashCode(): kotlin/Int // com.chrisjenx.yakcov.strings/Decimal.hashCode|hashCode(){}[0]
+    final fun toString(): kotlin/String // com.chrisjenx.yakcov.strings/Decimal.toString|toString(){}[0]
+    final fun validate(kotlin/String): com.chrisjenx.yakcov/ValidationResult // com.chrisjenx.yakcov.strings/Decimal.validate|validate(kotlin.String){}[0]
+}
+
+final object com.chrisjenx.yakcov.strings/Email : com.chrisjenx.yakcov/ValueValidatorRule<kotlin/String> { // com.chrisjenx.yakcov.strings/Email|null[0]
+    final fun equals(kotlin/Any?): kotlin/Boolean // com.chrisjenx.yakcov.strings/Email.equals|equals(kotlin.Any?){}[0]
+    final fun hashCode(): kotlin/Int // com.chrisjenx.yakcov.strings/Email.hashCode|hashCode(){}[0]
+    final fun toString(): kotlin/String // com.chrisjenx.yakcov.strings/Email.toString|toString(){}[0]
+    final fun validate(kotlin/String): com.chrisjenx.yakcov/ValidationResult // com.chrisjenx.yakcov.strings/Email.validate|validate(kotlin.String){}[0]
+}
+
+final object com.chrisjenx.yakcov.strings/HexColor : com.chrisjenx.yakcov/ValueValidatorRule<kotlin/String> { // com.chrisjenx.yakcov.strings/HexColor|null[0]
+    final fun equals(kotlin/Any?): kotlin/Boolean // com.chrisjenx.yakcov.strings/HexColor.equals|equals(kotlin.Any?){}[0]
+    final fun hashCode(): kotlin/Int // com.chrisjenx.yakcov.strings/HexColor.hashCode|hashCode(){}[0]
+    final fun toString(): kotlin/String // com.chrisjenx.yakcov.strings/HexColor.toString|toString(){}[0]
+    final fun validate(kotlin/String): com.chrisjenx.yakcov/ValidationResult // com.chrisjenx.yakcov.strings/HexColor.validate|validate(kotlin.String){}[0]
+}
+
+final object com.chrisjenx.yakcov.strings/Numeric : com.chrisjenx.yakcov/ValueValidatorRule<kotlin/String> { // com.chrisjenx.yakcov.strings/Numeric|null[0]
+    final fun equals(kotlin/Any?): kotlin/Boolean // com.chrisjenx.yakcov.strings/Numeric.equals|equals(kotlin.Any?){}[0]
+    final fun hashCode(): kotlin/Int // com.chrisjenx.yakcov.strings/Numeric.hashCode|hashCode(){}[0]
+    final fun toString(): kotlin/String // com.chrisjenx.yakcov.strings/Numeric.toString|toString(){}[0]
+    final fun validate(kotlin/String): com.chrisjenx.yakcov/ValidationResult // com.chrisjenx.yakcov.strings/Numeric.validate|validate(kotlin.String){}[0]
+}
+
+final object com.chrisjenx.yakcov.strings/PhoneFormat : com.chrisjenx.yakcov/ValueValidatorRule<kotlin/String> { // com.chrisjenx.yakcov.strings/PhoneFormat|null[0]
+    final fun equals(kotlin/Any?): kotlin/Boolean // com.chrisjenx.yakcov.strings/PhoneFormat.equals|equals(kotlin.Any?){}[0]
+    final fun hashCode(): kotlin/Int // com.chrisjenx.yakcov.strings/PhoneFormat.hashCode|hashCode(){}[0]
+    final fun toString(): kotlin/String // com.chrisjenx.yakcov.strings/PhoneFormat.toString|toString(){}[0]
+    final fun validate(kotlin/String): com.chrisjenx.yakcov/ValidationResult // com.chrisjenx.yakcov.strings/PhoneFormat.validate|validate(kotlin.String){}[0]
+}
+
+final object com.chrisjenx.yakcov.strings/Required : com.chrisjenx.yakcov/ValueValidatorRule<kotlin/String> { // com.chrisjenx.yakcov.strings/Required|null[0]
+    final fun equals(kotlin/Any?): kotlin/Boolean // com.chrisjenx.yakcov.strings/Required.equals|equals(kotlin.Any?){}[0]
+    final fun hashCode(): kotlin/Int // com.chrisjenx.yakcov.strings/Required.hashCode|hashCode(){}[0]
+    final fun toString(): kotlin/String // com.chrisjenx.yakcov.strings/Required.toString|toString(){}[0]
+    final fun validate(kotlin/String): com.chrisjenx.yakcov/ValidationResult // com.chrisjenx.yakcov.strings/Required.validate|validate(kotlin.String){}[0]
+}
+
+final object yakcov.library.generated.resources/Res { // yakcov.library.generated.resources/Res|null[0]
+    final fun getUri(kotlin/String): kotlin/String // yakcov.library.generated.resources/Res.getUri|getUri(kotlin.String){}[0]
+    final suspend fun readBytes(kotlin/String): kotlin/ByteArray // yakcov.library.generated.resources/Res.readBytes|readBytes(kotlin.String){}[0]
+
+    final object array // yakcov.library.generated.resources/Res.array|null[0]
+
+    final object drawable // yakcov.library.generated.resources/Res.drawable|null[0]
+
+    final object font // yakcov.library.generated.resources/Res.font|null[0]
+
+    final object plurals // yakcov.library.generated.resources/Res.plurals|null[0]
+
+    final object string // yakcov.library.generated.resources/Res.string|null[0]
+}
+
+final val com.chrisjenx.yakcov.generic/com_chrisjenx_yakcov_generic_GenericValueValidator$stableprop // com.chrisjenx.yakcov.generic/com_chrisjenx_yakcov_generic_GenericValueValidator$stableprop|#static{}com_chrisjenx_yakcov_generic_GenericValueValidator$stableprop[0]
+final val com.chrisjenx.yakcov.generic/com_chrisjenx_yakcov_generic_InList$stableprop // com.chrisjenx.yakcov.generic/com_chrisjenx_yakcov_generic_InList$stableprop|#static{}com_chrisjenx_yakcov_generic_InList$stableprop[0]
+final val com.chrisjenx.yakcov.generic/com_chrisjenx_yakcov_generic_InRange$stableprop // com.chrisjenx.yakcov.generic/com_chrisjenx_yakcov_generic_InRange$stableprop|#static{}com_chrisjenx_yakcov_generic_InRange$stableprop[0]
+final val com.chrisjenx.yakcov.generic/com_chrisjenx_yakcov_generic_IsChecked$stableprop // com.chrisjenx.yakcov.generic/com_chrisjenx_yakcov_generic_IsChecked$stableprop|#static{}com_chrisjenx_yakcov_generic_IsChecked$stableprop[0]
+final val com.chrisjenx.yakcov.generic/com_chrisjenx_yakcov_generic_IsNotChecked$stableprop // com.chrisjenx.yakcov.generic/com_chrisjenx_yakcov_generic_IsNotChecked$stableprop|#static{}com_chrisjenx_yakcov_generic_IsNotChecked$stableprop[0]
+final val com.chrisjenx.yakcov.generic/com_chrisjenx_yakcov_generic_ListNotEmpty$stableprop // com.chrisjenx.yakcov.generic/com_chrisjenx_yakcov_generic_ListNotEmpty$stableprop|#static{}com_chrisjenx_yakcov_generic_ListNotEmpty$stableprop[0]
+final val com.chrisjenx.yakcov.generic/com_chrisjenx_yakcov_generic_Max$stableprop // com.chrisjenx.yakcov.generic/com_chrisjenx_yakcov_generic_Max$stableprop|#static{}com_chrisjenx_yakcov_generic_Max$stableprop[0]
+final val com.chrisjenx.yakcov.generic/com_chrisjenx_yakcov_generic_Min$stableprop // com.chrisjenx.yakcov.generic/com_chrisjenx_yakcov_generic_Min$stableprop|#static{}com_chrisjenx_yakcov_generic_Min$stableprop[0]
+final val com.chrisjenx.yakcov.generic/com_chrisjenx_yakcov_generic_Required$stableprop // com.chrisjenx.yakcov.generic/com_chrisjenx_yakcov_generic_Required$stableprop|#static{}com_chrisjenx_yakcov_generic_Required$stableprop[0]
+final val com.chrisjenx.yakcov.strings/com_chrisjenx_yakcov_strings_DayValidation$stableprop // com.chrisjenx.yakcov.strings/com_chrisjenx_yakcov_strings_DayValidation$stableprop|#static{}com_chrisjenx_yakcov_strings_DayValidation$stableprop[0]
+final val com.chrisjenx.yakcov.strings/com_chrisjenx_yakcov_strings_Decimal$stableprop // com.chrisjenx.yakcov.strings/com_chrisjenx_yakcov_strings_Decimal$stableprop|#static{}com_chrisjenx_yakcov_strings_Decimal$stableprop[0]
+final val com.chrisjenx.yakcov.strings/com_chrisjenx_yakcov_strings_Email$stableprop // com.chrisjenx.yakcov.strings/com_chrisjenx_yakcov_strings_Email$stableprop|#static{}com_chrisjenx_yakcov_strings_Email$stableprop[0]
+final val com.chrisjenx.yakcov.strings/com_chrisjenx_yakcov_strings_HexColor$stableprop // com.chrisjenx.yakcov.strings/com_chrisjenx_yakcov_strings_HexColor$stableprop|#static{}com_chrisjenx_yakcov_strings_HexColor$stableprop[0]
+final val com.chrisjenx.yakcov.strings/com_chrisjenx_yakcov_strings_MaxLength$stableprop // com.chrisjenx.yakcov.strings/com_chrisjenx_yakcov_strings_MaxLength$stableprop|#static{}com_chrisjenx_yakcov_strings_MaxLength$stableprop[0]
+final val com.chrisjenx.yakcov.strings/com_chrisjenx_yakcov_strings_MaxValue$stableprop // com.chrisjenx.yakcov.strings/com_chrisjenx_yakcov_strings_MaxValue$stableprop|#static{}com_chrisjenx_yakcov_strings_MaxValue$stableprop[0]
+final val com.chrisjenx.yakcov.strings/com_chrisjenx_yakcov_strings_MinLength$stableprop // com.chrisjenx.yakcov.strings/com_chrisjenx_yakcov_strings_MinLength$stableprop|#static{}com_chrisjenx_yakcov_strings_MinLength$stableprop[0]
+final val com.chrisjenx.yakcov.strings/com_chrisjenx_yakcov_strings_MinValue$stableprop // com.chrisjenx.yakcov.strings/com_chrisjenx_yakcov_strings_MinValue$stableprop|#static{}com_chrisjenx_yakcov_strings_MinValue$stableprop[0]
+final val com.chrisjenx.yakcov.strings/com_chrisjenx_yakcov_strings_MonthValidation$stableprop // com.chrisjenx.yakcov.strings/com_chrisjenx_yakcov_strings_MonthValidation$stableprop|#static{}com_chrisjenx_yakcov_strings_MonthValidation$stableprop[0]
+final val com.chrisjenx.yakcov.strings/com_chrisjenx_yakcov_strings_Numeric$stableprop // com.chrisjenx.yakcov.strings/com_chrisjenx_yakcov_strings_Numeric$stableprop|#static{}com_chrisjenx_yakcov_strings_Numeric$stableprop[0]
+final val com.chrisjenx.yakcov.strings/com_chrisjenx_yakcov_strings_OneOf$stableprop // com.chrisjenx.yakcov.strings/com_chrisjenx_yakcov_strings_OneOf$stableprop|#static{}com_chrisjenx_yakcov_strings_OneOf$stableprop[0]
+final val com.chrisjenx.yakcov.strings/com_chrisjenx_yakcov_strings_Phone$stableprop // com.chrisjenx.yakcov.strings/com_chrisjenx_yakcov_strings_Phone$stableprop|#static{}com_chrisjenx_yakcov_strings_Phone$stableprop[0]
+final val com.chrisjenx.yakcov.strings/com_chrisjenx_yakcov_strings_PhoneFormat$stableprop // com.chrisjenx.yakcov.strings/com_chrisjenx_yakcov_strings_PhoneFormat$stableprop|#static{}com_chrisjenx_yakcov_strings_PhoneFormat$stableprop[0]
+final val com.chrisjenx.yakcov.strings/com_chrisjenx_yakcov_strings_Required$stableprop // com.chrisjenx.yakcov.strings/com_chrisjenx_yakcov_strings_Required$stableprop|#static{}com_chrisjenx_yakcov_strings_Required$stableprop[0]
+final val com.chrisjenx.yakcov.strings/com_chrisjenx_yakcov_strings_TextFieldValueValidator$stableprop // com.chrisjenx.yakcov.strings/com_chrisjenx_yakcov_strings_TextFieldValueValidator$stableprop|#static{}com_chrisjenx_yakcov_strings_TextFieldValueValidator$stableprop[0]
+final val com.chrisjenx.yakcov.strings/com_chrisjenx_yakcov_strings_YearValidation$stableprop // com.chrisjenx.yakcov.strings/com_chrisjenx_yakcov_strings_YearValidation$stableprop|#static{}com_chrisjenx_yakcov_strings_YearValidation$stableprop[0]
+final val com.chrisjenx.yakcov/com_chrisjenx_yakcov_FieldValidationState$stableprop // com.chrisjenx.yakcov/com_chrisjenx_yakcov_FieldValidationState$stableprop|#static{}com_chrisjenx_yakcov_FieldValidationState$stableprop[0]
+final val com.chrisjenx.yakcov/com_chrisjenx_yakcov_FieldValidationState_$serializer$stableprop // com.chrisjenx.yakcov/com_chrisjenx_yakcov_FieldValidationState_$serializer$stableprop|#static{}com_chrisjenx_yakcov_FieldValidationState_$serializer$stableprop[0]
+final val com.chrisjenx.yakcov/com_chrisjenx_yakcov_FieldValidator$stableprop // com.chrisjenx.yakcov/com_chrisjenx_yakcov_FieldValidator$stableprop|#static{}com_chrisjenx_yakcov_FieldValidator$stableprop[0]
+final val com.chrisjenx.yakcov/com_chrisjenx_yakcov_FieldValidatorEvent_Reset$stableprop // com.chrisjenx.yakcov/com_chrisjenx_yakcov_FieldValidatorEvent_Reset$stableprop|#static{}com_chrisjenx_yakcov_FieldValidatorEvent_Reset$stableprop[0]
+final val com.chrisjenx.yakcov/com_chrisjenx_yakcov_FieldValidatorEvent_Validated$stableprop // com.chrisjenx.yakcov/com_chrisjenx_yakcov_FieldValidatorEvent_Validated$stableprop|#static{}com_chrisjenx_yakcov_FieldValidatorEvent_Validated$stableprop[0]
+final val com.chrisjenx.yakcov/com_chrisjenx_yakcov_FieldValidatorEvent_ValueChanged$stableprop // com.chrisjenx.yakcov/com_chrisjenx_yakcov_FieldValidatorEvent_ValueChanged$stableprop|#static{}com_chrisjenx_yakcov_FieldValidatorEvent_ValueChanged$stableprop[0]
+final val com.chrisjenx.yakcov/com_chrisjenx_yakcov_Optional$stableprop // com.chrisjenx.yakcov/com_chrisjenx_yakcov_Optional$stableprop|#static{}com_chrisjenx_yakcov_Optional$stableprop[0]
+final val com.chrisjenx.yakcov/com_chrisjenx_yakcov_RegularValidationResult$stableprop // com.chrisjenx.yakcov/com_chrisjenx_yakcov_RegularValidationResult$stableprop|#static{}com_chrisjenx_yakcov_RegularValidationResult$stableprop[0]
+final val com.chrisjenx.yakcov/com_chrisjenx_yakcov_ResourceValidationResult$stableprop // com.chrisjenx.yakcov/com_chrisjenx_yakcov_ResourceValidationResult$stableprop|#static{}com_chrisjenx_yakcov_ResourceValidationResult$stableprop[0]
+final val com.chrisjenx.yakcov/com_chrisjenx_yakcov_ShakingState$stableprop // com.chrisjenx.yakcov/com_chrisjenx_yakcov_ShakingState$stableprop|#static{}com_chrisjenx_yakcov_ShakingState$stableprop[0]
+final val com.chrisjenx.yakcov/com_chrisjenx_yakcov_ShakingState_Strength$stableprop // com.chrisjenx.yakcov/com_chrisjenx_yakcov_ShakingState_Strength$stableprop|#static{}com_chrisjenx_yakcov_ShakingState_Strength$stableprop[0]
+final val com.chrisjenx.yakcov/com_chrisjenx_yakcov_ShakingState_Strength_Custom$stableprop // com.chrisjenx.yakcov/com_chrisjenx_yakcov_ShakingState_Strength_Custom$stableprop|#static{}com_chrisjenx_yakcov_ShakingState_Strength_Custom$stableprop[0]
+final val com.chrisjenx.yakcov/com_chrisjenx_yakcov_ShakingState_Strength_Normal$stableprop // com.chrisjenx.yakcov/com_chrisjenx_yakcov_ShakingState_Strength_Normal$stableprop|#static{}com_chrisjenx_yakcov_ShakingState_Strength_Normal$stableprop[0]
+final val com.chrisjenx.yakcov/com_chrisjenx_yakcov_ShakingState_Strength_Strong$stableprop // com.chrisjenx.yakcov/com_chrisjenx_yakcov_ShakingState_Strength_Strong$stableprop|#static{}com_chrisjenx_yakcov_ShakingState_Strength_Strong$stableprop[0]
+final val com.chrisjenx.yakcov/com_chrisjenx_yakcov_ValueValidator$stableprop // com.chrisjenx.yakcov/com_chrisjenx_yakcov_ValueValidator$stableprop|#static{}com_chrisjenx_yakcov_ValueValidator$stableprop[0]
+final val com.chrisjenx.yakcov/com_chrisjenx_yakcov_ValueValidator_InternalState_Initial$stableprop // com.chrisjenx.yakcov/com_chrisjenx_yakcov_ValueValidator_InternalState_Initial$stableprop|#static{}com_chrisjenx_yakcov_ValueValidator_InternalState_Initial$stableprop[0]
+final val com.chrisjenx.yakcov/com_chrisjenx_yakcov_ValueValidator_InternalState_Validating$stableprop // com.chrisjenx.yakcov/com_chrisjenx_yakcov_ValueValidator_InternalState_Validating$stableprop|#static{}com_chrisjenx_yakcov_ValueValidator_InternalState_Validating$stableprop[0]
+final val yakcov.library.generated.resources/allDrawableResources // yakcov.library.generated.resources/allDrawableResources|@yakcov.library.generated.resources.Res{}allDrawableResources[0]
+    final fun (yakcov.library.generated.resources/Res).<get-allDrawableResources>(): kotlin.collections/Map<kotlin/String, org.jetbrains.compose.resources/DrawableResource> // yakcov.library.generated.resources/allDrawableResources.<get-allDrawableResources>|<get-allDrawableResources>@yakcov.library.generated.resources.Res(){}[0]
+final val yakcov.library.generated.resources/allFontResources // yakcov.library.generated.resources/allFontResources|@yakcov.library.generated.resources.Res{}allFontResources[0]
+    final fun (yakcov.library.generated.resources/Res).<get-allFontResources>(): kotlin.collections/Map<kotlin/String, org.jetbrains.compose.resources/FontResource> // yakcov.library.generated.resources/allFontResources.<get-allFontResources>|<get-allFontResources>@yakcov.library.generated.resources.Res(){}[0]
+final val yakcov.library.generated.resources/allPluralStringResources // yakcov.library.generated.resources/allPluralStringResources|@yakcov.library.generated.resources.Res{}allPluralStringResources[0]
+    final fun (yakcov.library.generated.resources/Res).<get-allPluralStringResources>(): kotlin.collections/Map<kotlin/String, org.jetbrains.compose.resources/PluralStringResource> // yakcov.library.generated.resources/allPluralStringResources.<get-allPluralStringResources>|<get-allPluralStringResources>@yakcov.library.generated.resources.Res(){}[0]
+final val yakcov.library.generated.resources/allStringArrayResources // yakcov.library.generated.resources/allStringArrayResources|@yakcov.library.generated.resources.Res{}allStringArrayResources[0]
+    final fun (yakcov.library.generated.resources/Res).<get-allStringArrayResources>(): kotlin.collections/Map<kotlin/String, org.jetbrains.compose.resources/StringArrayResource> // yakcov.library.generated.resources/allStringArrayResources.<get-allStringArrayResources>|<get-allStringArrayResources>@yakcov.library.generated.resources.Res(){}[0]
+final val yakcov.library.generated.resources/allStringResources // yakcov.library.generated.resources/allStringResources|@yakcov.library.generated.resources.Res{}allStringResources[0]
+    final fun (yakcov.library.generated.resources/Res).<get-allStringResources>(): kotlin.collections/Map<kotlin/String, org.jetbrains.compose.resources/StringResource> // yakcov.library.generated.resources/allStringResources.<get-allStringResources>|<get-allStringResources>@yakcov.library.generated.resources.Res(){}[0]
+final val yakcov.library.generated.resources/ruleDay // yakcov.library.generated.resources/ruleDay|@yakcov.library.generated.resources.Res.string{}ruleDay[0]
+    final fun (yakcov.library.generated.resources/Res.string).<get-ruleDay>(): org.jetbrains.compose.resources/StringResource // yakcov.library.generated.resources/ruleDay.<get-ruleDay>|<get-ruleDay>@yakcov.library.generated.resources.Res.string(){}[0]
+final val yakcov.library.generated.resources/ruleDecimal // yakcov.library.generated.resources/ruleDecimal|@yakcov.library.generated.resources.Res.string{}ruleDecimal[0]
+    final fun (yakcov.library.generated.resources/Res.string).<get-ruleDecimal>(): org.jetbrains.compose.resources/StringResource // yakcov.library.generated.resources/ruleDecimal.<get-ruleDecimal>|<get-ruleDecimal>@yakcov.library.generated.resources.Res.string(){}[0]
+final val yakcov.library.generated.resources/ruleEmail // yakcov.library.generated.resources/ruleEmail|@yakcov.library.generated.resources.Res.string{}ruleEmail[0]
+    final fun (yakcov.library.generated.resources/Res.string).<get-ruleEmail>(): org.jetbrains.compose.resources/StringResource // yakcov.library.generated.resources/ruleEmail.<get-ruleEmail>|<get-ruleEmail>@yakcov.library.generated.resources.Res.string(){}[0]
+final val yakcov.library.generated.resources/ruleHexColor // yakcov.library.generated.resources/ruleHexColor|@yakcov.library.generated.resources.Res.string{}ruleHexColor[0]
+    final fun (yakcov.library.generated.resources/Res.string).<get-ruleHexColor>(): org.jetbrains.compose.resources/StringResource // yakcov.library.generated.resources/ruleHexColor.<get-ruleHexColor>|<get-ruleHexColor>@yakcov.library.generated.resources.Res.string(){}[0]
+final val yakcov.library.generated.resources/ruleInList // yakcov.library.generated.resources/ruleInList|@yakcov.library.generated.resources.Res.string{}ruleInList[0]
+    final fun (yakcov.library.generated.resources/Res.string).<get-ruleInList>(): org.jetbrains.compose.resources/StringResource // yakcov.library.generated.resources/ruleInList.<get-ruleInList>|<get-ruleInList>@yakcov.library.generated.resources.Res.string(){}[0]
+final val yakcov.library.generated.resources/ruleInvalidDate // yakcov.library.generated.resources/ruleInvalidDate|@yakcov.library.generated.resources.Res.string{}ruleInvalidDate[0]
+    final fun (yakcov.library.generated.resources/Res.string).<get-ruleInvalidDate>(): org.jetbrains.compose.resources/StringResource // yakcov.library.generated.resources/ruleInvalidDate.<get-ruleInvalidDate>|<get-ruleInvalidDate>@yakcov.library.generated.resources.Res.string(){}[0]
+final val yakcov.library.generated.resources/ruleIsChecked // yakcov.library.generated.resources/ruleIsChecked|@yakcov.library.generated.resources.Res.string{}ruleIsChecked[0]
+    final fun (yakcov.library.generated.resources/Res.string).<get-ruleIsChecked>(): org.jetbrains.compose.resources/StringResource // yakcov.library.generated.resources/ruleIsChecked.<get-ruleIsChecked>|<get-ruleIsChecked>@yakcov.library.generated.resources.Res.string(){}[0]
+final val yakcov.library.generated.resources/ruleIsEmptyList // yakcov.library.generated.resources/ruleIsEmptyList|@yakcov.library.generated.resources.Res.string{}ruleIsEmptyList[0]
+    final fun (yakcov.library.generated.resources/Res.string).<get-ruleIsEmptyList>(): org.jetbrains.compose.resources/StringResource // yakcov.library.generated.resources/ruleIsEmptyList.<get-ruleIsEmptyList>|<get-ruleIsEmptyList>@yakcov.library.generated.resources.Res.string(){}[0]
+final val yakcov.library.generated.resources/ruleIsNotChecked // yakcov.library.generated.resources/ruleIsNotChecked|@yakcov.library.generated.resources.Res.string{}ruleIsNotChecked[0]
+    final fun (yakcov.library.generated.resources/Res.string).<get-ruleIsNotChecked>(): org.jetbrains.compose.resources/StringResource // yakcov.library.generated.resources/ruleIsNotChecked.<get-ruleIsNotChecked>|<get-ruleIsNotChecked>@yakcov.library.generated.resources.Res.string(){}[0]
+final val yakcov.library.generated.resources/ruleMaxLength // yakcov.library.generated.resources/ruleMaxLength|@yakcov.library.generated.resources.Res.string{}ruleMaxLength[0]
+    final fun (yakcov.library.generated.resources/Res.string).<get-ruleMaxLength>(): org.jetbrains.compose.resources/StringResource // yakcov.library.generated.resources/ruleMaxLength.<get-ruleMaxLength>|<get-ruleMaxLength>@yakcov.library.generated.resources.Res.string(){}[0]
+final val yakcov.library.generated.resources/ruleMaxValue // yakcov.library.generated.resources/ruleMaxValue|@yakcov.library.generated.resources.Res.string{}ruleMaxValue[0]
+    final fun (yakcov.library.generated.resources/Res.string).<get-ruleMaxValue>(): org.jetbrains.compose.resources/StringResource // yakcov.library.generated.resources/ruleMaxValue.<get-ruleMaxValue>|<get-ruleMaxValue>@yakcov.library.generated.resources.Res.string(){}[0]
+final val yakcov.library.generated.resources/ruleMinLength // yakcov.library.generated.resources/ruleMinLength|@yakcov.library.generated.resources.Res.string{}ruleMinLength[0]
+    final fun (yakcov.library.generated.resources/Res.string).<get-ruleMinLength>(): org.jetbrains.compose.resources/StringResource // yakcov.library.generated.resources/ruleMinLength.<get-ruleMinLength>|<get-ruleMinLength>@yakcov.library.generated.resources.Res.string(){}[0]
+final val yakcov.library.generated.resources/ruleMinLengthNoWhitespace // yakcov.library.generated.resources/ruleMinLengthNoWhitespace|@yakcov.library.generated.resources.Res.string{}ruleMinLengthNoWhitespace[0]
+    final fun (yakcov.library.generated.resources/Res.string).<get-ruleMinLengthNoWhitespace>(): org.jetbrains.compose.resources/StringResource // yakcov.library.generated.resources/ruleMinLengthNoWhitespace.<get-ruleMinLengthNoWhitespace>|<get-ruleMinLengthNoWhitespace>@yakcov.library.generated.resources.Res.string(){}[0]
+final val yakcov.library.generated.resources/ruleMinValue // yakcov.library.generated.resources/ruleMinValue|@yakcov.library.generated.resources.Res.string{}ruleMinValue[0]
+    final fun (yakcov.library.generated.resources/Res.string).<get-ruleMinValue>(): org.jetbrains.compose.resources/StringResource // yakcov.library.generated.resources/ruleMinValue.<get-ruleMinValue>|<get-ruleMinValue>@yakcov.library.generated.resources.Res.string(){}[0]
+final val yakcov.library.generated.resources/ruleMonth // yakcov.library.generated.resources/ruleMonth|@yakcov.library.generated.resources.Res.string{}ruleMonth[0]
+    final fun (yakcov.library.generated.resources/Res.string).<get-ruleMonth>(): org.jetbrains.compose.resources/StringResource // yakcov.library.generated.resources/ruleMonth.<get-ruleMonth>|<get-ruleMonth>@yakcov.library.generated.resources.Res.string(){}[0]
+final val yakcov.library.generated.resources/ruleNotEmptyList // yakcov.library.generated.resources/ruleNotEmptyList|@yakcov.library.generated.resources.Res.string{}ruleNotEmptyList[0]
+    final fun (yakcov.library.generated.resources/Res.string).<get-ruleNotEmptyList>(): org.jetbrains.compose.resources/StringResource // yakcov.library.generated.resources/ruleNotEmptyList.<get-ruleNotEmptyList>|<get-ruleNotEmptyList>@yakcov.library.generated.resources.Res.string(){}[0]
+final val yakcov.library.generated.resources/ruleNotNull // yakcov.library.generated.resources/ruleNotNull|@yakcov.library.generated.resources.Res.string{}ruleNotNull[0]
+    final fun (yakcov.library.generated.resources/Res.string).<get-ruleNotNull>(): org.jetbrains.compose.resources/StringResource // yakcov.library.generated.resources/ruleNotNull.<get-ruleNotNull>|<get-ruleNotNull>@yakcov.library.generated.resources.Res.string(){}[0]
+final val yakcov.library.generated.resources/ruleNumeric // yakcov.library.generated.resources/ruleNumeric|@yakcov.library.generated.resources.Res.string{}ruleNumeric[0]
+    final fun (yakcov.library.generated.resources/Res.string).<get-ruleNumeric>(): org.jetbrains.compose.resources/StringResource // yakcov.library.generated.resources/ruleNumeric.<get-ruleNumeric>|<get-ruleNumeric>@yakcov.library.generated.resources.Res.string(){}[0]
+final val yakcov.library.generated.resources/rulePasswords // yakcov.library.generated.resources/rulePasswords|@yakcov.library.generated.resources.Res.string{}rulePasswords[0]
+    final fun (yakcov.library.generated.resources/Res.string).<get-rulePasswords>(): org.jetbrains.compose.resources/StringResource // yakcov.library.generated.resources/rulePasswords.<get-rulePasswords>|<get-rulePasswords>@yakcov.library.generated.resources.Res.string(){}[0]
+final val yakcov.library.generated.resources/rulePhone // yakcov.library.generated.resources/rulePhone|@yakcov.library.generated.resources.Res.string{}rulePhone[0]
+    final fun (yakcov.library.generated.resources/Res.string).<get-rulePhone>(): org.jetbrains.compose.resources/StringResource // yakcov.library.generated.resources/rulePhone.<get-rulePhone>|<get-rulePhone>@yakcov.library.generated.resources.Res.string(){}[0]
+final val yakcov.library.generated.resources/ruleRequired // yakcov.library.generated.resources/ruleRequired|@yakcov.library.generated.resources.Res.string{}ruleRequired[0]
+    final fun (yakcov.library.generated.resources/Res.string).<get-ruleRequired>(): org.jetbrains.compose.resources/StringResource // yakcov.library.generated.resources/ruleRequired.<get-ruleRequired>|<get-ruleRequired>@yakcov.library.generated.resources.Res.string(){}[0]
+final val yakcov.library.generated.resources/ruleYear // yakcov.library.generated.resources/ruleYear|@yakcov.library.generated.resources.Res.string{}ruleYear[0]
+    final fun (yakcov.library.generated.resources/Res.string).<get-ruleYear>(): org.jetbrains.compose.resources/StringResource // yakcov.library.generated.resources/ruleYear.<get-ruleYear>|<get-ruleYear>@yakcov.library.generated.resources.Res.string(){}[0]
+final val yakcov.library.generated.resources/yakcov_library_generated_resources_Res$stableprop // yakcov.library.generated.resources/yakcov_library_generated_resources_Res$stableprop|#static{}yakcov_library_generated_resources_Res$stableprop[0]
+final val yakcov.library.generated.resources/yakcov_library_generated_resources_Res_array$stableprop // yakcov.library.generated.resources/yakcov_library_generated_resources_Res_array$stableprop|#static{}yakcov_library_generated_resources_Res_array$stableprop[0]
+final val yakcov.library.generated.resources/yakcov_library_generated_resources_Res_drawable$stableprop // yakcov.library.generated.resources/yakcov_library_generated_resources_Res_drawable$stableprop|#static{}yakcov_library_generated_resources_Res_drawable$stableprop[0]
+final val yakcov.library.generated.resources/yakcov_library_generated_resources_Res_font$stableprop // yakcov.library.generated.resources/yakcov_library_generated_resources_Res_font$stableprop|#static{}yakcov_library_generated_resources_Res_font$stableprop[0]
+final val yakcov.library.generated.resources/yakcov_library_generated_resources_Res_plurals$stableprop // yakcov.library.generated.resources/yakcov_library_generated_resources_Res_plurals$stableprop|#static{}yakcov_library_generated_resources_Res_plurals$stableprop[0]
+final val yakcov.library.generated.resources/yakcov_library_generated_resources_Res_string$stableprop // yakcov.library.generated.resources/yakcov_library_generated_resources_Res_string$stableprop|#static{}yakcov_library_generated_resources_Res_string$stableprop[0]
+
+final fun (androidx.compose.ui/Modifier).com.chrisjenx.yakcov/onFocusCursorToEnd(androidx.compose.ui.text.input/TextFieldValue, kotlin/Function1<androidx.compose.ui.text.input/TextFieldValue, kotlin/Unit>, kotlinx.coroutines/CoroutineScope?, kotlin/Boolean, androidx.compose.runtime/Composer?, kotlin/Int, kotlin/Int): androidx.compose.ui/Modifier // com.chrisjenx.yakcov/onFocusCursorToEnd|onFocusCursorToEnd@androidx.compose.ui.Modifier(androidx.compose.ui.text.input.TextFieldValue;kotlin.Function1<androidx.compose.ui.text.input.TextFieldValue,kotlin.Unit>;kotlinx.coroutines.CoroutineScope?;kotlin.Boolean;androidx.compose.runtime.Composer?;kotlin.Int;kotlin.Int){}[0]
+final fun (androidx.compose.ui/Modifier).com.chrisjenx.yakcov/onFocusLost(kotlin/Function0<kotlin/Unit>): androidx.compose.ui/Modifier // com.chrisjenx.yakcov/onFocusLost|onFocusLost@androidx.compose.ui.Modifier(kotlin.Function0<kotlin.Unit>){}[0]
+final fun (androidx.compose.ui/Modifier).com.chrisjenx.yakcov/shakable(com.chrisjenx.yakcov/ShakingState): androidx.compose.ui/Modifier // com.chrisjenx.yakcov/shakable|shakable@androidx.compose.ui.Modifier(com.chrisjenx.yakcov.ShakingState){}[0]
+final fun (androidx.compose.ui/Modifier).com.chrisjenx.yakcov/shakeOnInvalid(kotlin/Boolean, kotlin/Int): androidx.compose.ui/Modifier // com.chrisjenx.yakcov/shakeOnInvalid|shakeOnInvalid@androidx.compose.ui.Modifier(kotlin.Boolean;kotlin.Int){}[0]
+final fun (androidx.compose.ui/Modifier).com.chrisjenx.yakcov/validationBehavior(kotlin/Boolean, kotlin/Int? = ..., kotlin/Function0<kotlin/Unit>? = ...): androidx.compose.ui/Modifier // com.chrisjenx.yakcov/validationBehavior|validationBehavior@androidx.compose.ui.Modifier(kotlin.Boolean;kotlin.Int?;kotlin.Function0<kotlin.Unit>?){}[0]
+final fun (androidx.compose.ui/Modifier).com.chrisjenx.yakcov/validationConfig(com.chrisjenx.yakcov/ValueValidator<*, *>, kotlin/Boolean = ..., kotlin/Boolean = ..., kotlin/Boolean = ...): androidx.compose.ui/Modifier // com.chrisjenx.yakcov/validationConfig|validationConfig@androidx.compose.ui.Modifier(com.chrisjenx.yakcov.ValueValidator<*,*>;kotlin.Boolean;kotlin.Boolean;kotlin.Boolean){}[0]
+final fun (com.chrisjenx.yakcov/FieldValidationState).com.chrisjenx.yakcov/supportingText(kotlin/String?, androidx.compose.runtime/Composer?, kotlin/Int, kotlin/Int): kotlin/Function2<androidx.compose.runtime/Composer, kotlin/Int, kotlin/Unit>? // com.chrisjenx.yakcov/supportingText|supportingText@com.chrisjenx.yakcov.FieldValidationState(kotlin.String?;androidx.compose.runtime.Composer?;kotlin.Int;kotlin.Int){}[0]
+final fun (com.chrisjenx.yakcov/FieldValidationState).com.chrisjenx.yakcov/text(kotlin/String?, androidx.compose.runtime/Composer?, kotlin/Int, kotlin/Int): kotlin/String? // com.chrisjenx.yakcov/text|text@com.chrisjenx.yakcov.FieldValidationState(kotlin.String?;androidx.compose.runtime.Composer?;kotlin.Int;kotlin.Int){}[0]
+final fun (kotlin.collections/List<com.chrisjenx.yakcov/FieldValidationState>).com.chrisjenx.yakcov/hasNoErrors(): kotlin/Boolean // com.chrisjenx.yakcov/hasNoErrors|hasNoErrors@kotlin.collections.List<com.chrisjenx.yakcov.FieldValidationState>(){}[0]
+final fun (kotlin.collections/List<com.chrisjenx.yakcov/FieldValidator<*>>).com.chrisjenx.yakcov/validate(): kotlin/Boolean // com.chrisjenx.yakcov/validate|validate@kotlin.collections.List<com.chrisjenx.yakcov.FieldValidator<*>>(){}[0]
+final fun (kotlin.collections/List<com.chrisjenx.yakcov/ValueValidator<*, *>>).com.chrisjenx.yakcov/validate(): kotlin/Boolean // com.chrisjenx.yakcov/validate|validate@kotlin.collections.List<com.chrisjenx.yakcov.ValueValidator<*,*>>(){}[0]
+final fun (kotlin.collections/List<com.chrisjenx.yakcov/ValueValidator<*, *>>).com.chrisjenx.yakcov/validateWithResult(): com.chrisjenx.yakcov/ValidationResult.Outcome // com.chrisjenx.yakcov/validateWithResult|validateWithResult@kotlin.collections.List<com.chrisjenx.yakcov.ValueValidator<*,*>>(){}[0]
+final fun (kotlin/String?).com.chrisjenx.yakcov/isEmail(): kotlin/Boolean // com.chrisjenx.yakcov/isEmail|isEmail@kotlin.String?(){}[0]
+final fun (kotlin/String?).com.chrisjenx.yakcov/isPhoneNumber(kotlin/String? = ...): kotlin/Boolean // com.chrisjenx.yakcov/isPhoneNumber|isPhoneNumber@kotlin.String?(kotlin.String?){}[0]
+final fun (kotlin/String?).com.chrisjenx.yakcov/isPhoneNumberFormat(): kotlin/Boolean // com.chrisjenx.yakcov/isPhoneNumberFormat|isPhoneNumberFormat@kotlin.String?(){}[0]
+final fun <#A: kotlin/Any?> (com.chrisjenx.yakcov/ValueValidatorRule<#A>).com.chrisjenx.yakcov/onlyWhen(androidx.compose.runtime/State<kotlin/Boolean>): com.chrisjenx.yakcov/ValueValidatorRule<#A> // com.chrisjenx.yakcov/onlyWhen|onlyWhen@com.chrisjenx.yakcov.ValueValidatorRule<0:0>(androidx.compose.runtime.State<kotlin.Boolean>){0§<kotlin.Any?>}[0]
+final fun <#A: kotlin/Any?> (com.chrisjenx.yakcov/ValueValidatorRule<#A>).com.chrisjenx.yakcov/onlyWhen(kotlin/Boolean): com.chrisjenx.yakcov/ValueValidatorRule<#A> // com.chrisjenx.yakcov/onlyWhen|onlyWhen@com.chrisjenx.yakcov.ValueValidatorRule<0:0>(kotlin.Boolean){0§<kotlin.Any?>}[0]
+final fun <#A: kotlin/Any?> (com.chrisjenx.yakcov/ValueValidatorRule<#A>).com.chrisjenx.yakcov/toFieldState(#A, kotlin/Boolean): com.chrisjenx.yakcov/FieldValidationState // com.chrisjenx.yakcov/toFieldState|toFieldState@com.chrisjenx.yakcov.ValueValidatorRule<0:0>(0:0;kotlin.Boolean){0§<kotlin.Any?>}[0]
+final fun <#A: kotlin/Any?> (kotlin.collections/List<com.chrisjenx.yakcov/ValueValidatorRule<#A>>).com.chrisjenx.yakcov/toFieldState(#A, kotlin/Boolean): com.chrisjenx.yakcov/FieldValidationState // com.chrisjenx.yakcov/toFieldState|toFieldState@kotlin.collections.List<com.chrisjenx.yakcov.ValueValidatorRule<0:0>>(0:0;kotlin.Boolean){0§<kotlin.Any?>}[0]
+final fun <#A: kotlin/Any?> com.chrisjenx.yakcov.generic/rememberGenericValueValidator(#A, kotlin.collections/List<com.chrisjenx.yakcov/ValueValidatorRule<#A>>, kotlin/Boolean, kotlin/Boolean, kotlin/String?, androidx.compose.runtime/Composer?, kotlin/Int, kotlin/Int): com.chrisjenx.yakcov.generic/GenericValueValidator<#A> // com.chrisjenx.yakcov.generic/rememberGenericValueValidator|rememberGenericValueValidator(0:0;kotlin.collections.List<com.chrisjenx.yakcov.ValueValidatorRule<0:0>>;kotlin.Boolean;kotlin.Boolean;kotlin.String?;androidx.compose.runtime.Composer?;kotlin.Int;kotlin.Int){0§<kotlin.Any?>}[0]
+final fun com.chrisjenx.yakcov.generic/com_chrisjenx_yakcov_generic_GenericValueValidator$stableprop_getter(): kotlin/Int // com.chrisjenx.yakcov.generic/com_chrisjenx_yakcov_generic_GenericValueValidator$stableprop_getter|com_chrisjenx_yakcov_generic_GenericValueValidator$stableprop_getter(){}[0]
+final fun com.chrisjenx.yakcov.generic/com_chrisjenx_yakcov_generic_InList$stableprop_getter(): kotlin/Int // com.chrisjenx.yakcov.generic/com_chrisjenx_yakcov_generic_InList$stableprop_getter|com_chrisjenx_yakcov_generic_InList$stableprop_getter(){}[0]
+final fun com.chrisjenx.yakcov.generic/com_chrisjenx_yakcov_generic_InRange$stableprop_getter(): kotlin/Int // com.chrisjenx.yakcov.generic/com_chrisjenx_yakcov_generic_InRange$stableprop_getter|com_chrisjenx_yakcov_generic_InRange$stableprop_getter(){}[0]
+final fun com.chrisjenx.yakcov.generic/com_chrisjenx_yakcov_generic_IsChecked$stableprop_getter(): kotlin/Int // com.chrisjenx.yakcov.generic/com_chrisjenx_yakcov_generic_IsChecked$stableprop_getter|com_chrisjenx_yakcov_generic_IsChecked$stableprop_getter(){}[0]
+final fun com.chrisjenx.yakcov.generic/com_chrisjenx_yakcov_generic_IsNotChecked$stableprop_getter(): kotlin/Int // com.chrisjenx.yakcov.generic/com_chrisjenx_yakcov_generic_IsNotChecked$stableprop_getter|com_chrisjenx_yakcov_generic_IsNotChecked$stableprop_getter(){}[0]
+final fun com.chrisjenx.yakcov.generic/com_chrisjenx_yakcov_generic_ListNotEmpty$stableprop_getter(): kotlin/Int // com.chrisjenx.yakcov.generic/com_chrisjenx_yakcov_generic_ListNotEmpty$stableprop_getter|com_chrisjenx_yakcov_generic_ListNotEmpty$stableprop_getter(){}[0]
+final fun com.chrisjenx.yakcov.generic/com_chrisjenx_yakcov_generic_Max$stableprop_getter(): kotlin/Int // com.chrisjenx.yakcov.generic/com_chrisjenx_yakcov_generic_Max$stableprop_getter|com_chrisjenx_yakcov_generic_Max$stableprop_getter(){}[0]
+final fun com.chrisjenx.yakcov.generic/com_chrisjenx_yakcov_generic_Min$stableprop_getter(): kotlin/Int // com.chrisjenx.yakcov.generic/com_chrisjenx_yakcov_generic_Min$stableprop_getter|com_chrisjenx_yakcov_generic_Min$stableprop_getter(){}[0]
+final fun com.chrisjenx.yakcov.generic/com_chrisjenx_yakcov_generic_Required$stableprop_getter(): kotlin/Int // com.chrisjenx.yakcov.generic/com_chrisjenx_yakcov_generic_Required$stableprop_getter|com_chrisjenx_yakcov_generic_Required$stableprop_getter(){}[0]
+final fun com.chrisjenx.yakcov.strings/PasswordMatches(com.chrisjenx.yakcov/ValueValidator<androidx.compose.ui.text.input/TextFieldValue, *>): com.chrisjenx.yakcov/ValueValidatorRule<kotlin/String> // com.chrisjenx.yakcov.strings/PasswordMatches|PasswordMatches(com.chrisjenx.yakcov.ValueValidator<androidx.compose.ui.text.input.TextFieldValue,*>){}[0]
+final fun com.chrisjenx.yakcov.strings/PasswordMatches(com.chrisjenx.yakcov/ValueValidator<kotlin/String, *>): com.chrisjenx.yakcov/ValueValidatorRule<kotlin/String> // com.chrisjenx.yakcov.strings/PasswordMatches|PasswordMatches(com.chrisjenx.yakcov.ValueValidator<kotlin.String,*>){}[0]
+final fun com.chrisjenx.yakcov.strings/com_chrisjenx_yakcov_strings_DayValidation$stableprop_getter(): kotlin/Int // com.chrisjenx.yakcov.strings/com_chrisjenx_yakcov_strings_DayValidation$stableprop_getter|com_chrisjenx_yakcov_strings_DayValidation$stableprop_getter(){}[0]
+final fun com.chrisjenx.yakcov.strings/com_chrisjenx_yakcov_strings_Decimal$stableprop_getter(): kotlin/Int // com.chrisjenx.yakcov.strings/com_chrisjenx_yakcov_strings_Decimal$stableprop_getter|com_chrisjenx_yakcov_strings_Decimal$stableprop_getter(){}[0]
+final fun com.chrisjenx.yakcov.strings/com_chrisjenx_yakcov_strings_Email$stableprop_getter(): kotlin/Int // com.chrisjenx.yakcov.strings/com_chrisjenx_yakcov_strings_Email$stableprop_getter|com_chrisjenx_yakcov_strings_Email$stableprop_getter(){}[0]
+final fun com.chrisjenx.yakcov.strings/com_chrisjenx_yakcov_strings_HexColor$stableprop_getter(): kotlin/Int // com.chrisjenx.yakcov.strings/com_chrisjenx_yakcov_strings_HexColor$stableprop_getter|com_chrisjenx_yakcov_strings_HexColor$stableprop_getter(){}[0]
+final fun com.chrisjenx.yakcov.strings/com_chrisjenx_yakcov_strings_MaxLength$stableprop_getter(): kotlin/Int // com.chrisjenx.yakcov.strings/com_chrisjenx_yakcov_strings_MaxLength$stableprop_getter|com_chrisjenx_yakcov_strings_MaxLength$stableprop_getter(){}[0]
+final fun com.chrisjenx.yakcov.strings/com_chrisjenx_yakcov_strings_MaxValue$stableprop_getter(): kotlin/Int // com.chrisjenx.yakcov.strings/com_chrisjenx_yakcov_strings_MaxValue$stableprop_getter|com_chrisjenx_yakcov_strings_MaxValue$stableprop_getter(){}[0]
+final fun com.chrisjenx.yakcov.strings/com_chrisjenx_yakcov_strings_MinLength$stableprop_getter(): kotlin/Int // com.chrisjenx.yakcov.strings/com_chrisjenx_yakcov_strings_MinLength$stableprop_getter|com_chrisjenx_yakcov_strings_MinLength$stableprop_getter(){}[0]
+final fun com.chrisjenx.yakcov.strings/com_chrisjenx_yakcov_strings_MinValue$stableprop_getter(): kotlin/Int // com.chrisjenx.yakcov.strings/com_chrisjenx_yakcov_strings_MinValue$stableprop_getter|com_chrisjenx_yakcov_strings_MinValue$stableprop_getter(){}[0]
+final fun com.chrisjenx.yakcov.strings/com_chrisjenx_yakcov_strings_MonthValidation$stableprop_getter(): kotlin/Int // com.chrisjenx.yakcov.strings/com_chrisjenx_yakcov_strings_MonthValidation$stableprop_getter|com_chrisjenx_yakcov_strings_MonthValidation$stableprop_getter(){}[0]
+final fun com.chrisjenx.yakcov.strings/com_chrisjenx_yakcov_strings_Numeric$stableprop_getter(): kotlin/Int // com.chrisjenx.yakcov.strings/com_chrisjenx_yakcov_strings_Numeric$stableprop_getter|com_chrisjenx_yakcov_strings_Numeric$stableprop_getter(){}[0]
+final fun com.chrisjenx.yakcov.strings/com_chrisjenx_yakcov_strings_OneOf$stableprop_getter(): kotlin/Int // com.chrisjenx.yakcov.strings/com_chrisjenx_yakcov_strings_OneOf$stableprop_getter|com_chrisjenx_yakcov_strings_OneOf$stableprop_getter(){}[0]
+final fun com.chrisjenx.yakcov.strings/com_chrisjenx_yakcov_strings_Phone$stableprop_getter(): kotlin/Int // com.chrisjenx.yakcov.strings/com_chrisjenx_yakcov_strings_Phone$stableprop_getter|com_chrisjenx_yakcov_strings_Phone$stableprop_getter(){}[0]
+final fun com.chrisjenx.yakcov.strings/com_chrisjenx_yakcov_strings_PhoneFormat$stableprop_getter(): kotlin/Int // com.chrisjenx.yakcov.strings/com_chrisjenx_yakcov_strings_PhoneFormat$stableprop_getter|com_chrisjenx_yakcov_strings_PhoneFormat$stableprop_getter(){}[0]
+final fun com.chrisjenx.yakcov.strings/com_chrisjenx_yakcov_strings_Required$stableprop_getter(): kotlin/Int // com.chrisjenx.yakcov.strings/com_chrisjenx_yakcov_strings_Required$stableprop_getter|com_chrisjenx_yakcov_strings_Required$stableprop_getter(){}[0]
+final fun com.chrisjenx.yakcov.strings/com_chrisjenx_yakcov_strings_TextFieldValueValidator$stableprop_getter(): kotlin/Int // com.chrisjenx.yakcov.strings/com_chrisjenx_yakcov_strings_TextFieldValueValidator$stableprop_getter|com_chrisjenx_yakcov_strings_TextFieldValueValidator$stableprop_getter(){}[0]
+final fun com.chrisjenx.yakcov.strings/com_chrisjenx_yakcov_strings_YearValidation$stableprop_getter(): kotlin/Int // com.chrisjenx.yakcov.strings/com_chrisjenx_yakcov_strings_YearValidation$stableprop_getter|com_chrisjenx_yakcov_strings_YearValidation$stableprop_getter(){}[0]
+final fun com.chrisjenx.yakcov.strings/rememberTextFieldValueValidator(androidx.compose.runtime/MutableState<androidx.compose.ui.text.input/TextFieldValue>?, kotlin.collections/List<com.chrisjenx.yakcov/ValueValidatorRule<kotlin/String>>?, kotlin/Boolean, kotlin/Boolean, kotlin/String?, androidx.compose.runtime/Composer?, kotlin/Int, kotlin/Int): com.chrisjenx.yakcov.strings/TextFieldValueValidator // com.chrisjenx.yakcov.strings/rememberTextFieldValueValidator|rememberTextFieldValueValidator(androidx.compose.runtime.MutableState<androidx.compose.ui.text.input.TextFieldValue>?;kotlin.collections.List<com.chrisjenx.yakcov.ValueValidatorRule<kotlin.String>>?;kotlin.Boolean;kotlin.Boolean;kotlin.String?;androidx.compose.runtime.Composer?;kotlin.Int;kotlin.Int){}[0]
+final fun com.chrisjenx.yakcov.strings/rememberTextFieldValueValidator(kotlin/String, kotlin.collections/List<com.chrisjenx.yakcov/ValueValidatorRule<kotlin/String>>?, kotlin/Boolean, kotlin/Boolean, kotlin/String?, androidx.compose.runtime/Composer?, kotlin/Int, kotlin/Int): com.chrisjenx.yakcov.strings/TextFieldValueValidator // com.chrisjenx.yakcov.strings/rememberTextFieldValueValidator|rememberTextFieldValueValidator(kotlin.String;kotlin.collections.List<com.chrisjenx.yakcov.ValueValidatorRule<kotlin.String>>?;kotlin.Boolean;kotlin.Boolean;kotlin.String?;androidx.compose.runtime.Composer?;kotlin.Int;kotlin.Int){}[0]
+final fun com.chrisjenx.yakcov/com_chrisjenx_yakcov_FieldValidationState$stableprop_getter(): kotlin/Int // com.chrisjenx.yakcov/com_chrisjenx_yakcov_FieldValidationState$stableprop_getter|com_chrisjenx_yakcov_FieldValidationState$stableprop_getter(){}[0]
+final fun com.chrisjenx.yakcov/com_chrisjenx_yakcov_FieldValidationState_$serializer$stableprop_getter(): kotlin/Int // com.chrisjenx.yakcov/com_chrisjenx_yakcov_FieldValidationState_$serializer$stableprop_getter|com_chrisjenx_yakcov_FieldValidationState_$serializer$stableprop_getter(){}[0]
+final fun com.chrisjenx.yakcov/com_chrisjenx_yakcov_FieldValidator$stableprop_getter(): kotlin/Int // com.chrisjenx.yakcov/com_chrisjenx_yakcov_FieldValidator$stableprop_getter|com_chrisjenx_yakcov_FieldValidator$stableprop_getter(){}[0]
+final fun com.chrisjenx.yakcov/com_chrisjenx_yakcov_FieldValidatorEvent_Reset$stableprop_getter(): kotlin/Int // com.chrisjenx.yakcov/com_chrisjenx_yakcov_FieldValidatorEvent_Reset$stableprop_getter|com_chrisjenx_yakcov_FieldValidatorEvent_Reset$stableprop_getter(){}[0]
+final fun com.chrisjenx.yakcov/com_chrisjenx_yakcov_FieldValidatorEvent_Validated$stableprop_getter(): kotlin/Int // com.chrisjenx.yakcov/com_chrisjenx_yakcov_FieldValidatorEvent_Validated$stableprop_getter|com_chrisjenx_yakcov_FieldValidatorEvent_Validated$stableprop_getter(){}[0]
+final fun com.chrisjenx.yakcov/com_chrisjenx_yakcov_FieldValidatorEvent_ValueChanged$stableprop_getter(): kotlin/Int // com.chrisjenx.yakcov/com_chrisjenx_yakcov_FieldValidatorEvent_ValueChanged$stableprop_getter|com_chrisjenx_yakcov_FieldValidatorEvent_ValueChanged$stableprop_getter(){}[0]
+final fun com.chrisjenx.yakcov/com_chrisjenx_yakcov_Optional$stableprop_getter(): kotlin/Int // com.chrisjenx.yakcov/com_chrisjenx_yakcov_Optional$stableprop_getter|com_chrisjenx_yakcov_Optional$stableprop_getter(){}[0]
+final fun com.chrisjenx.yakcov/com_chrisjenx_yakcov_RegularValidationResult$stableprop_getter(): kotlin/Int // com.chrisjenx.yakcov/com_chrisjenx_yakcov_RegularValidationResult$stableprop_getter|com_chrisjenx_yakcov_RegularValidationResult$stableprop_getter(){}[0]
+final fun com.chrisjenx.yakcov/com_chrisjenx_yakcov_ResourceValidationResult$stableprop_getter(): kotlin/Int // com.chrisjenx.yakcov/com_chrisjenx_yakcov_ResourceValidationResult$stableprop_getter|com_chrisjenx_yakcov_ResourceValidationResult$stableprop_getter(){}[0]
+final fun com.chrisjenx.yakcov/com_chrisjenx_yakcov_ShakingState$stableprop_getter(): kotlin/Int // com.chrisjenx.yakcov/com_chrisjenx_yakcov_ShakingState$stableprop_getter|com_chrisjenx_yakcov_ShakingState$stableprop_getter(){}[0]
+final fun com.chrisjenx.yakcov/com_chrisjenx_yakcov_ShakingState_Strength$stableprop_getter(): kotlin/Int // com.chrisjenx.yakcov/com_chrisjenx_yakcov_ShakingState_Strength$stableprop_getter|com_chrisjenx_yakcov_ShakingState_Strength$stableprop_getter(){}[0]
+final fun com.chrisjenx.yakcov/com_chrisjenx_yakcov_ShakingState_Strength_Custom$stableprop_getter(): kotlin/Int // com.chrisjenx.yakcov/com_chrisjenx_yakcov_ShakingState_Strength_Custom$stableprop_getter|com_chrisjenx_yakcov_ShakingState_Strength_Custom$stableprop_getter(){}[0]
+final fun com.chrisjenx.yakcov/com_chrisjenx_yakcov_ShakingState_Strength_Normal$stableprop_getter(): kotlin/Int // com.chrisjenx.yakcov/com_chrisjenx_yakcov_ShakingState_Strength_Normal$stableprop_getter|com_chrisjenx_yakcov_ShakingState_Strength_Normal$stableprop_getter(){}[0]
+final fun com.chrisjenx.yakcov/com_chrisjenx_yakcov_ShakingState_Strength_Strong$stableprop_getter(): kotlin/Int // com.chrisjenx.yakcov/com_chrisjenx_yakcov_ShakingState_Strength_Strong$stableprop_getter|com_chrisjenx_yakcov_ShakingState_Strength_Strong$stableprop_getter(){}[0]
+final fun com.chrisjenx.yakcov/com_chrisjenx_yakcov_ValueValidator$stableprop_getter(): kotlin/Int // com.chrisjenx.yakcov/com_chrisjenx_yakcov_ValueValidator$stableprop_getter|com_chrisjenx_yakcov_ValueValidator$stableprop_getter(){}[0]
+final fun com.chrisjenx.yakcov/com_chrisjenx_yakcov_ValueValidator_InternalState_Initial$stableprop_getter(): kotlin/Int // com.chrisjenx.yakcov/com_chrisjenx_yakcov_ValueValidator_InternalState_Initial$stableprop_getter|com_chrisjenx_yakcov_ValueValidator_InternalState_Initial$stableprop_getter(){}[0]
+final fun com.chrisjenx.yakcov/com_chrisjenx_yakcov_ValueValidator_InternalState_Validating$stableprop_getter(): kotlin/Int // com.chrisjenx.yakcov/com_chrisjenx_yakcov_ValueValidator_InternalState_Validating$stableprop_getter|com_chrisjenx_yakcov_ValueValidator_InternalState_Validating$stableprop_getter(){}[0]
+final fun com.chrisjenx.yakcov/rememberShakingState(com.chrisjenx.yakcov/ShakingState.Strength?, com.chrisjenx.yakcov/ShakingState.Direction?, androidx.compose.runtime/Composer?, kotlin/Int, kotlin/Int): com.chrisjenx.yakcov/ShakingState // com.chrisjenx.yakcov/rememberShakingState|rememberShakingState(com.chrisjenx.yakcov.ShakingState.Strength?;com.chrisjenx.yakcov.ShakingState.Direction?;androidx.compose.runtime.Composer?;kotlin.Int;kotlin.Int){}[0]
+final fun yakcov.library.generated.resources/yakcov_library_generated_resources_Res$stableprop_getter(): kotlin/Int // yakcov.library.generated.resources/yakcov_library_generated_resources_Res$stableprop_getter|yakcov_library_generated_resources_Res$stableprop_getter(){}[0]
+final fun yakcov.library.generated.resources/yakcov_library_generated_resources_Res_array$stableprop_getter(): kotlin/Int // yakcov.library.generated.resources/yakcov_library_generated_resources_Res_array$stableprop_getter|yakcov_library_generated_resources_Res_array$stableprop_getter(){}[0]
+final fun yakcov.library.generated.resources/yakcov_library_generated_resources_Res_drawable$stableprop_getter(): kotlin/Int // yakcov.library.generated.resources/yakcov_library_generated_resources_Res_drawable$stableprop_getter|yakcov_library_generated_resources_Res_drawable$stableprop_getter(){}[0]
+final fun yakcov.library.generated.resources/yakcov_library_generated_resources_Res_font$stableprop_getter(): kotlin/Int // yakcov.library.generated.resources/yakcov_library_generated_resources_Res_font$stableprop_getter|yakcov_library_generated_resources_Res_font$stableprop_getter(){}[0]
+final fun yakcov.library.generated.resources/yakcov_library_generated_resources_Res_plurals$stableprop_getter(): kotlin/Int // yakcov.library.generated.resources/yakcov_library_generated_resources_Res_plurals$stableprop_getter|yakcov_library_generated_resources_Res_plurals$stableprop_getter(){}[0]
+final fun yakcov.library.generated.resources/yakcov_library_generated_resources_Res_string$stableprop_getter(): kotlin/Int // yakcov.library.generated.resources/yakcov_library_generated_resources_Res_string$stableprop_getter|yakcov_library_generated_resources_Res_string$stableprop_getter(){}[0]

--- a/library/build.gradle.kts
+++ b/library/build.gradle.kts
@@ -22,6 +22,15 @@ kotlin {
         freeCompilerArgs.add("-Xexpect-actual-classes")
     }
 
+    // Public API drift gate: `checkLegacyAbi` fails CI when the committed dump under
+    // library/api/ doesn't match the current public surface; `updateLegacyAbi` regenerates it.
+    // klib.enabled covers the native/JS/Wasm targets alongside JVM/Android.
+    @OptIn(org.jetbrains.kotlin.gradle.dsl.abi.ExperimentalAbiValidation::class)
+    abiValidation {
+        enabled.set(true)
+        klib.enabled.set(true)
+    }
+
     applyDefaultHierarchyTemplate()
     androidTarget {
         compilations.all {

--- a/library/build.gradle.kts
+++ b/library/build.gradle.kts
@@ -24,18 +24,35 @@ kotlin {
 
     // Public API drift gate: `checkKotlinAbi` fails CI when the committed dump under
     // library/api/ doesn't match the current public surface; `updateKotlinAbi` regenerates it.
-    // klib.enabled covers the native/JS/Wasm targets alongside JVM/Android.
     //
-    // Note: the `Checks-Api` CI job that runs checkKotlinAbi executes on ubuntu-latest, so the
-    // Apple klib targets recorded in library/api/library.klib.api are NOT actually validated
-    // there — they pass via inference because klib.keepUnsupportedTargets defaults to `true`.
-    // Common-API drift is still caught through the js/wasmJs entries, which DO run on Linux.
-    // klib.enabled.set(true) below is redundant (it already defaults to `true`); kept as
-    // documentation that klib validation is intentionally on, not an oversight.
+    // `enabled` must be set REFLECTIVELY, and the two channels are why. Kotlin 2.4 (`[next]`)
+    // removed both `enabled` and `klib`; naming either one statically is a deprecation *error*
+    // that fails this script's own compilation — breaking not just the continue-on-error `next`
+    // CI legs but `release.yml`'s next-channel publish. Kotlin 2.3 (`[stable]`) has the opposite
+    // requirement: without `enabled = true` the check task is SKIPPED, so an empty block leaves
+    // a gate that always passes and validates nothing. Verified both directions by mutation test
+    // (add a public symbol; the check must FAIL) — an empty block passed it vacuously.
+    //
+    // `klib` is not set at all: klib validation already defaults to on.
+    //
+    // On 2.4 the reflective lookup finds nothing and no-ops, but the block's presence auto-enables
+    // validation there — and the committed dump, generated on stable's compiler, will NOT match it
+    // (2.4 stops emitting the synthetic DefaultConstructorMarker bridge constructors). The dump is
+    // therefore toolchain-specific by nature and `Checks-Api` (unmatrixed, stable-only) is the sole
+    // place it is enforced. `release.yml` excludes this task from its next-channel dry-run for the
+    // same reason.
+    //
+    // Note: the `Checks-Api` job runs on ubuntu-latest, so the Apple entries in
+    // library/api/library.klib.api are NOT actually validated — they pass by inference because
+    // klib.keepUnsupportedTargets defaults to `true`. Common-API drift is still caught via the
+    // js/wasmJs entries, which DO run on Linux.
     @OptIn(org.jetbrains.kotlin.gradle.dsl.abi.ExperimentalAbiValidation::class)
     abiValidation {
-        enabled.set(true)
-        klib.enabled.set(true)
+        @Suppress("UNCHECKED_CAST")
+        val enabledProperty = javaClass.methods
+            .firstOrNull { it.name == "getEnabled" && it.parameterCount == 0 }
+            ?.invoke(this) as? org.gradle.api.provider.Property<Boolean>
+        enabledProperty?.set(true)
     }
 
     applyDefaultHierarchyTemplate()

--- a/library/build.gradle.kts
+++ b/library/build.gradle.kts
@@ -22,9 +22,16 @@ kotlin {
         freeCompilerArgs.add("-Xexpect-actual-classes")
     }
 
-    // Public API drift gate: `checkLegacyAbi` fails CI when the committed dump under
-    // library/api/ doesn't match the current public surface; `updateLegacyAbi` regenerates it.
+    // Public API drift gate: `checkKotlinAbi` fails CI when the committed dump under
+    // library/api/ doesn't match the current public surface; `updateKotlinAbi` regenerates it.
     // klib.enabled covers the native/JS/Wasm targets alongside JVM/Android.
+    //
+    // Note: the `Checks-Api` CI job that runs checkKotlinAbi executes on ubuntu-latest, so the
+    // Apple klib targets recorded in library/api/library.klib.api are NOT actually validated
+    // there — they pass via inference because klib.keepUnsupportedTargets defaults to `true`.
+    // Common-API drift is still caught through the js/wasmJs entries, which DO run on Linux.
+    // klib.enabled.set(true) below is redundant (it already defaults to `true`); kept as
+    // documentation that klib validation is intentionally on, not an oversight.
     @OptIn(org.jetbrains.kotlin.gradle.dsl.abi.ExperimentalAbiValidation::class)
     abiValidation {
         enabled.set(true)

--- a/library/src/commonMain/kotlin/com/chrisjenx/yakcov/FieldValidator.kt
+++ b/library/src/commonMain/kotlin/com/chrisjenx/yakcov/FieldValidator.kt
@@ -69,6 +69,17 @@ class FieldValidator<V>(
     var state: FieldValidationState by mutableStateOf(seedState(initial))
         private set
 
+    /**
+     * Monotonic count of submit-intent validations — every [validate] call, and no others. Pass this
+     * as the `shakeTrigger` of [validationBehavior]/[shakeOnInvalid]: a repeated invalid submit
+     * produces an *equal* [FieldValidationState], so shake cannot be driven by diffing that state.
+     *
+     * Deliberately not bumped by [onFocusLost] (focus loss reveals the error without shaking) nor
+     * reset by [reset] (it counts events, not state).
+     */
+    var attempts: Int by mutableStateOf(0)
+        private set
+
     /** Update the draft and revalidate, keeping the current showError (no error pop while typing). */
     fun onValueChange(value: V) {
         Snapshot.withMutableSnapshot {
@@ -78,17 +89,22 @@ class FieldValidator<V>(
         observer?.onEvent(FieldValidatorEvent.ValueChanged(this.value, state))
     }
 
-    /** Revalidate and show errors — call when the field loses focus. Alias for [validate]. */
-    fun onFocusLost(): Boolean = validate()
+    /** Revalidate and show errors — call when the field loses focus. Does not count as an attempt. */
+    fun onFocusLost(): Boolean = revealAndValidate(countAttempt = false)
 
     /**
-     * Revalidate, force errors visible, and report validity — call at submit time (or on focus loss
-     * via [onFocusLost]). Mirrors [ValueValidator.validate].
+     * Revalidate, force errors visible, and report validity — call at submit time. Increments
+     * [attempts]. Mirrors [ValueValidator.validate].
      *
      * @return `true` when the field is valid (no [ValidationResult.Outcome.ERROR]).
      */
-    fun validate(): Boolean {
-        revalidate(showError = true)
+    fun validate(): Boolean = revealAndValidate(countAttempt = true)
+
+    private fun revealAndValidate(countAttempt: Boolean): Boolean {
+        Snapshot.withMutableSnapshot {
+            revalidate(showError = true)
+            if (countAttempt) attempts++
+        }
         observer?.onEvent(FieldValidatorEvent.Validated(value, state))
         return !state.isError
     }

--- a/library/src/commonMain/kotlin/com/chrisjenx/yakcov/Modifiers.kt
+++ b/library/src/commonMain/kotlin/com/chrisjenx/yakcov/Modifiers.kt
@@ -1,5 +1,7 @@
 package com.chrisjenx.yakcov
 
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -37,4 +39,47 @@ fun Modifier.onFocusLost(onLost: () -> Unit): Modifier = composed {
         if (hadFocus && !focusState.hasFocus) onLost()
         hadFocus = focusState.hasFocus
     }
+}
+
+/** Shake parity constants — copied from the ValueValidator implementation they replace. */
+private val ShakeStrength = ShakingState.Strength.Custom(20f)
+private val ShakeDirection = ShakingState.Direction.LEFT_THEN_RIGHT
+private const val ShakeDurationMs = 20
+
+/**
+ * Invokes [onShake] when [trigger] changes while [isError] is true.
+ *
+ * The trigger value observed at first composition is treated as already-seen, so a field that is
+ * already in error (e.g. `initialValidate = true`) does not shake on its first frame. [trigger] must
+ * be monotonic: a counter that returns to its first-composition value will not fire.
+ *
+ * Internal so the trigger semantics can be tested without asserting on animation frames; the public
+ * entry point is [shakeOnInvalid].
+ */
+@Composable
+internal fun ShakeOnTriggerEffect(
+    isError: Boolean,
+    trigger: Int,
+    onShake: suspend () -> Unit,
+) {
+    val initialTrigger = remember { trigger }
+    LaunchedEffect(trigger) {
+        if (trigger != initialTrigger && isError) onShake()
+    }
+}
+
+/**
+ * Shakes this element when [trigger] changes while [isError] is true — the plain-value equivalent of
+ * `ValueValidator`'s `validationConfig(shakeOnInvalid = true)`, usable with no validator at all.
+ *
+ * Because a repeated invalid submit produces a structurally *equal* validation state, shake cannot be
+ * driven by diffing that state; pass a monotonic counter instead (`FieldValidator.attempts`, or a
+ * `submitAttempts` field in your reducer's model).
+ *
+ * @see validationBehavior for the bundled form.
+ */
+fun Modifier.shakeOnInvalid(isError: Boolean, trigger: Int): Modifier = composed {
+    val shakingState = remember { ShakingState(ShakeStrength, ShakeDirection) }
+    ShakeOnTriggerEffect(isError, trigger) { shakingState.shake(animationDuration = ShakeDurationMs) }
+    shakable(shakingState)
 }

--- a/library/src/commonMain/kotlin/com/chrisjenx/yakcov/Modifiers.kt
+++ b/library/src/commonMain/kotlin/com/chrisjenx/yakcov/Modifiers.kt
@@ -14,7 +14,9 @@ import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.text.TextRange
 import androidx.compose.ui.text.input.TextFieldValue
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 
 /**
  * Returns a [Modifier] that will modify how the field acts to user interaction and validation
@@ -86,8 +88,39 @@ internal fun ShakeOnTriggerEffect(
  */
 fun Modifier.shakeOnInvalid(isError: Boolean, trigger: Int): Modifier = composed {
     val shakingState = remember { ShakingState(ShakeStrength, ShakeDirection) }
-    ShakeOnTriggerEffect(isError, trigger) { shakingState.shake(animationDuration = ShakeDurationMs) }
-    shakable(shakingState)
+    shakeOnInvalidImpl(isError, trigger, shakingState)
+}
+
+/**
+ * [shakeOnInvalid] with an injected [shakingState], so tests can observe `xPosition` — the animated
+ * offset is otherwise trapped inside a `remember` no test can reach. Internal, not public: callers
+ * who want to own the state should use [shakable] + [ShakingState.shake] directly.
+ */
+internal fun Modifier.shakeOnInvalid(
+    isError: Boolean,
+    trigger: Int,
+    shakingState: ShakingState,
+): Modifier = composed { shakeOnInvalidImpl(isError, trigger, shakingState) }
+
+/** The single shake implementation shared by both [shakeOnInvalid] overloads. */
+@Composable
+private fun Modifier.shakeOnInvalidImpl(
+    isError: Boolean,
+    trigger: Int,
+    shakingState: ShakingState,
+): Modifier {
+    ShakeOnTriggerEffect(isError, trigger) {
+        try {
+            shakingState.shake(animationDuration = ShakeDurationMs)
+        } finally {
+            // ShakeOnTriggerEffect keys its LaunchedEffect on `trigger`, so a new trigger CANCELS
+            // this coroutine mid-animateTo. If the restart's isError guard then skips (the value
+            // was corrected inside the ~240ms shake window — autofill, paste, programmatic set),
+            // nothing would animate xPosition home and the field would render permanently offset.
+            withContext(NonCancellable) { shakingState.xPosition.snapTo(0f) }
+        }
+    }
+    return shakable(shakingState)
 }
 
 /**
@@ -98,7 +131,9 @@ fun Modifier.shakeOnInvalid(isError: Boolean, trigger: Int): Modifier = composed
  * a leading `Boolean`, and Kotlin resolves members over extensions, so a same-named free function
  * would silently bind to the member inside `with(validator) { }`.
  *
- * @param isError whether the field is currently showing an error — gates the shake.
+ * @param isError whether the field is currently showing an error. It gates *only* the shake, so with
+ *  the default `shakeTrigger = null` it is inert — passing your error state here without a trigger
+ *  reads as though it were wired up but changes nothing.
  * @param shakeTrigger a monotonic counter; `null` disables shake entirely.
  * @param onFocusLost invoked when the element loses focus; `null` adds no focus handling. Equivalent
  *  to chaining [onFocusLost] yourself.

--- a/library/src/commonMain/kotlin/com/chrisjenx/yakcov/Modifiers.kt
+++ b/library/src/commonMain/kotlin/com/chrisjenx/yakcov/Modifiers.kt
@@ -49,10 +49,17 @@ fun Modifier.onFocusLost(onLost: () -> Unit): Modifier = composed {
     }
 }
 
-/** Shake parity constants — copied from the ValueValidator implementation they replace. */
-private val ShakeStrength = ShakingState.Strength.Custom(20f)
-private val ShakeDirection = ShakingState.Direction.LEFT_THEN_RIGHT
-private const val ShakeDurationMs = 20
+/**
+ * Shake parity constants, matching `ValueValidator`'s own imperative shake so both paths feel
+ * identical. `internal` rather than `private` so tests assert against these values instead of
+ * re-typing the literals — a copy in a test drifts silently when the real ones are tuned.
+ *
+ * NOTE: `ValueValidator.kt` still spells the same values inline; unifying that too means editing a
+ * file this change deliberately leaves alone, so it stays a follow-up.
+ */
+internal val ShakeStrength = ShakingState.Strength.Custom(20f)
+internal val ShakeDirection = ShakingState.Direction.LEFT_THEN_RIGHT
+internal const val ShakeDurationMs = 20
 
 /**
  * Invokes [onShake] when [trigger] changes while [isError] is true.
@@ -87,7 +94,7 @@ internal fun ShakeOnTriggerEffect(
  * @see validationBehavior for the bundled form.
  */
 fun Modifier.shakeOnInvalid(isError: Boolean, trigger: Int): Modifier = composed {
-    val shakingState = remember { ShakingState(ShakeStrength, ShakeDirection) }
+    val shakingState = rememberShakingState(strength = ShakeStrength, direction = ShakeDirection)
     shakeOnInvalidImpl(isError, trigger, shakingState)
 }
 

--- a/library/src/commonMain/kotlin/com/chrisjenx/yakcov/Modifiers.kt
+++ b/library/src/commonMain/kotlin/com/chrisjenx/yakcov/Modifiers.kt
@@ -5,10 +5,16 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.composed
 import androidx.compose.ui.focus.onFocusChanged
+import androidx.compose.ui.text.TextRange
+import androidx.compose.ui.text.input.TextFieldValue
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
 
 /**
  * Returns a [Modifier] that will modify how the field acts to user interaction and validation
@@ -106,3 +112,34 @@ fun Modifier.validationBehavior(
 ): Modifier = this
     .then(if (onFocusLost != null) Modifier.onFocusLost(onLost = onFocusLost) else Modifier)
     .then(if (shakeTrigger != null) Modifier.shakeOnInvalid(isError, shakeTrigger) else Modifier)
+
+/**
+ * Moves the cursor to the end of the text when this element gains focus — the plain-value form of
+ * `TextFieldValueValidator`'s member of the same name, usable with no validator.
+ *
+ * `@Composable` rather than `composed {}` because the [scope] default is a composable call. The value
+ * is read through `rememberUpdatedState` so the deferred write sees the *live* text: the one-frame
+ * deferral is what makes the reversed [TextRange] land the cursor at the end.
+ *
+ * @param highlight when true, selects the whole text instead of collapsing to the end.
+ */
+@Composable
+fun Modifier.onFocusCursorToEnd(
+    value: TextFieldValue,
+    onValueChange: (TextFieldValue) -> Unit,
+    scope: CoroutineScope = rememberCoroutineScope(),
+    highlight: Boolean = false,
+): Modifier {
+    val currentValue by rememberUpdatedState(value)
+    val currentOnValueChange by rememberUpdatedState(onValueChange)
+    return onFocusChanged { focusState ->
+        if (focusState.isFocused) {
+            scope.launch {
+                val length = currentValue.text.length
+                // Yes, this is the wrong way around (bug workaround to get cursor to end)
+                val range = if (!highlight) TextRange(length) else TextRange(length, 0)
+                currentOnValueChange(currentValue.copy(selection = range))
+            }
+        }
+    }
+}

--- a/library/src/commonMain/kotlin/com/chrisjenx/yakcov/Modifiers.kt
+++ b/library/src/commonMain/kotlin/com/chrisjenx/yakcov/Modifiers.kt
@@ -83,3 +83,26 @@ fun Modifier.shakeOnInvalid(isError: Boolean, trigger: Int): Modifier = composed
     ShakeOnTriggerEffect(isError, trigger) { shakingState.shake(animationDuration = ShakeDurationMs) }
     shakable(shakingState)
 }
+
+/**
+ * Bundles focus-loss handling and shake-on-invalid over plain values — the plain-value counterpart to
+ * `ValueValidator`'s `validationConfig`, usable from a reducer's model or a headless [FieldValidator].
+ *
+ * Deliberately **not** named `validationConfig`: that name is already a `ValueValidator` member taking
+ * a leading `Boolean`, and Kotlin resolves members over extensions, so a same-named free function
+ * would silently bind to the member inside `with(validator) { }`.
+ *
+ * @param isError whether the field is currently showing an error — gates the shake.
+ * @param shakeTrigger a monotonic counter; `null` disables shake entirely.
+ * @param onFocusLost invoked when the element loses focus; `null` adds no focus handling. Equivalent
+ *  to chaining [onFocusLost] yourself.
+ * @see shakeOnInvalid
+ * @see onFocusLost
+ */
+fun Modifier.validationBehavior(
+    isError: Boolean,
+    shakeTrigger: Int? = null,
+    onFocusLost: (() -> Unit)? = null,
+): Modifier = this
+    .then(if (onFocusLost != null) Modifier.onFocusLost(onLost = onFocusLost) else Modifier)
+    .then(if (shakeTrigger != null) Modifier.shakeOnInvalid(isError, shakeTrigger) else Modifier)

--- a/library/src/commonMain/kotlin/com/chrisjenx/yakcov/strings/TextFieldValueValidator.kt
+++ b/library/src/commonMain/kotlin/com/chrisjenx/yakcov/strings/TextFieldValueValidator.kt
@@ -7,14 +7,12 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.focus.onFocusChanged
-import androidx.compose.ui.text.TextRange
 import androidx.compose.ui.text.input.TextFieldValue
 import com.chrisjenx.yakcov.ValueValidator
 import com.chrisjenx.yakcov.ValueValidator.Companion.defaultValidationSeparator
 import com.chrisjenx.yakcov.ValueValidatorRule
+import com.chrisjenx.yakcov.onFocusCursorToEnd
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.launch
 
 /**
  * We wrap the [TextFieldValue] to add validation support.
@@ -146,23 +144,18 @@ class TextFieldValueValidator(
      * Returns a [Modifier] that will move the cursor to the end of the text when the focus is gained.
      *
      * @param highlight if true will highlight the text as well
+     * @see com.chrisjenx.yakcov.onFocusCursorToEnd the plain-value form, usable without a validator.
      */
     @Composable
     fun Modifier.onFocusCursorToEnd(
         scope: CoroutineScope = rememberCoroutineScope(),
         highlight: Boolean = false,
-    ): Modifier {
-        return this.onFocusChanged {
-            if (it.isFocused) {
-                scope.launch {
-                    val range = if (!highlight) TextRange(value.text.length)
-                    // Yes, this is the wrong way around (bug workaround to get cursor to end)
-                    else TextRange(value.text.length, 0)
-                    value = value.copy(selection = range)
-                }
-            }
-        }
-    }
+    ): Modifier = onFocusCursorToEnd(
+        value = this@TextFieldValueValidator.value,
+        onValueChange = { this@TextFieldValueValidator.value = it },
+        scope = scope,
+        highlight = highlight,
+    )
 
     /**
      * Called when the field value changes, we also start validating. Generally prefer to use

--- a/library/src/commonTest/kotlin/com/chrisjenx/yakcov/FieldValidatorTest.kt
+++ b/library/src/commonTest/kotlin/com/chrisjenx/yakcov/FieldValidatorTest.kt
@@ -1,7 +1,6 @@
 package com.chrisjenx.yakcov
 
 import com.chrisjenx.yakcov.ValidationResult.Outcome
-import com.chrisjenx.yakcov.strings.Required
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -203,7 +202,7 @@ class FieldValidatorTest {
 
     @Test
     fun attempts_incrementsOnValidateOnly() {
-        val field = FieldValidator("", rules = listOf(Required))
+        val field = newValidator()
         assertEquals(0, field.attempts)
 
         field.onValueChange("a")
@@ -222,7 +221,7 @@ class FieldValidatorTest {
     fun attempts_survivesReset() {
         // attempts counts events, not state. Resetting it would itself register as a
         // trigger change and fire a spurious shake on an initialValidate field.
-        val field = FieldValidator("", rules = listOf(Required))
+        val field = newValidator()
         field.validate()
         assertEquals(1, field.attempts)
         field.reset()
@@ -231,9 +230,9 @@ class FieldValidatorTest {
 
     @Test
     fun onFocusLost_stillRevealsErrorsAndReportsValidity() {
-        val field = FieldValidator("", rules = listOf(Required))
+        val field = newValidator()
         assertFalse(field.state.showError)
-        assertFalse(field.onFocusLost(), "blank Required field is invalid")
+        assertFalse(field.onFocusLost(), "blank required field is invalid")
         assertTrue(field.state.showError)
         assertTrue(field.state.isError)
     }

--- a/library/src/commonTest/kotlin/com/chrisjenx/yakcov/FieldValidatorTest.kt
+++ b/library/src/commonTest/kotlin/com/chrisjenx/yakcov/FieldValidatorTest.kt
@@ -1,6 +1,7 @@
 package com.chrisjenx.yakcov
 
 import com.chrisjenx.yakcov.ValidationResult.Outcome
+import com.chrisjenx.yakcov.strings.Required
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -198,5 +199,42 @@ class FieldValidatorTest {
         v.validate()
         v.reset()
         assertEquals(3, checked)
+    }
+
+    @Test
+    fun attempts_incrementsOnValidateOnly() {
+        val field = FieldValidator("", rules = listOf(Required))
+        assertEquals(0, field.attempts)
+
+        field.onValueChange("a")
+        assertEquals(0, field.attempts, "typing must not count as a submit attempt")
+
+        field.onFocusLost()
+        assertEquals(0, field.attempts, "focus loss shows the error but must not shake")
+
+        field.validate()
+        assertEquals(1, field.attempts)
+        field.validate()
+        assertEquals(2, field.attempts, "each submit attempt must be distinguishable")
+    }
+
+    @Test
+    fun attempts_survivesReset() {
+        // attempts counts events, not state. Resetting it would itself register as a
+        // trigger change and fire a spurious shake on an initialValidate field.
+        val field = FieldValidator("", rules = listOf(Required))
+        field.validate()
+        assertEquals(1, field.attempts)
+        field.reset()
+        assertEquals(1, field.attempts)
+    }
+
+    @Test
+    fun onFocusLost_stillRevealsErrorsAndReportsValidity() {
+        val field = FieldValidator("", rules = listOf(Required))
+        assertFalse(field.state.showError)
+        assertFalse(field.onFocusLost(), "blank Required field is invalid")
+        assertTrue(field.state.showError)
+        assertTrue(field.state.isError)
     }
 }

--- a/library/src/commonTest/kotlin/com/chrisjenx/yakcov/ModifiersCursorTest.kt
+++ b/library/src/commonTest/kotlin/com/chrisjenx/yakcov/ModifiersCursorTest.kt
@@ -1,0 +1,111 @@
+package com.chrisjenx.yakcov
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.material3.TextField
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.requestFocus
+import androidx.compose.ui.test.v2.runComposeUiTest
+import androidx.compose.ui.text.TextRange
+import androidx.compose.ui.text.input.TextFieldValue
+import com.chrisjenx.yakcov.strings.TextFieldValueValidator
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+@OptIn(ExperimentalTestApi::class)
+class ModifiersCursorTest {
+
+    @Test
+    @AndroidJUnitIgnore
+    @JSIgnore
+    fun movesCursorToEndOnFocusGain() = runComposeUiTest {
+        var field by mutableStateOf(TextFieldValue("hello", selection = TextRange(0)))
+        setContent {
+            TextField(
+                value = field,
+                onValueChange = { field = it },
+                modifier = Modifier
+                    .testTag("a")
+                    .onFocusCursorToEnd(value = field, onValueChange = { field = it }),
+            )
+        }
+        onNodeWithTag("a").requestFocus()
+        waitForIdle()
+        assertEquals(TextRange(5), field.selection)
+    }
+
+    @Test
+    @AndroidJUnitIgnore
+    @JSIgnore
+    fun highlightSelectsWholeText() = runComposeUiTest {
+        var field by mutableStateOf(TextFieldValue("hello", selection = TextRange(0)))
+        setContent {
+            TextField(
+                value = field,
+                onValueChange = { field = it },
+                modifier = Modifier
+                    .testTag("a")
+                    .onFocusCursorToEnd(
+                        value = field,
+                        onValueChange = { field = it },
+                        highlight = true,
+                    ),
+            )
+        }
+        onNodeWithTag("a").requestFocus()
+        waitForIdle()
+        // Reversed range is a deliberate workaround to land the cursor at the end.
+        assertEquals(TextRange(5, 0), field.selection)
+    }
+
+    @Test
+    @AndroidJUnitIgnore
+    @JSIgnore
+    fun usesLiveValueNotCompositionTimeValue() = runComposeUiTest {
+        // Guards the rememberUpdatedState requirement: the deferred write must see the
+        // latest text, not the value captured when the modifier was created.
+        var field by mutableStateOf(TextFieldValue("", selection = TextRange(0)))
+        setContent {
+            Column {
+                TextField(
+                    value = field,
+                    onValueChange = { field = it },
+                    modifier = Modifier
+                        .testTag("a")
+                        .onFocusCursorToEnd(value = field, onValueChange = { field = it }),
+                )
+                TextField(value = "", onValueChange = {}, modifier = Modifier.testTag("b"))
+            }
+        }
+        onNodeWithTag("b").requestFocus()
+        field = field.copy(text = "abcd")
+        waitForIdle()
+        onNodeWithTag("a").requestFocus()
+        waitForIdle()
+        assertEquals(TextRange(4), field.selection)
+    }
+
+    @Test
+    @AndroidJUnitIgnore
+    @JSIgnore
+    fun memberOverloadStillMovesCursorToEnd() = runComposeUiTest {
+        val validator = TextFieldValueValidator(value = "hello")
+        setContent {
+            with(validator) {
+                TextField(
+                    value = validator.value,
+                    onValueChange = { validator.value = it },
+                    modifier = Modifier.testTag("a").onFocusCursorToEnd(),
+                )
+            }
+        }
+        onNodeWithTag("a").requestFocus()
+        waitForIdle()
+        assertEquals(TextRange(5), validator.value.selection)
+    }
+}

--- a/library/src/commonTest/kotlin/com/chrisjenx/yakcov/ModifiersShakeTest.kt
+++ b/library/src/commonTest/kotlin/com/chrisjenx/yakcov/ModifiersShakeTest.kt
@@ -1,10 +1,17 @@
 package com.chrisjenx.yakcov
 
+import androidx.compose.foundation.layout.Column
+import androidx.compose.material3.TextField
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.requestFocus
 import androidx.compose.ui.test.v2.runComposeUiTest
+import com.chrisjenx.yakcov.strings.TextFieldValueValidator
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
@@ -97,5 +104,62 @@ class ModifiersShakeTest {
         present = true        // recomposed fresh: 5 becomes the new baseline
         waitForIdle()
         assertEquals(0, shakes)
+    }
+
+    @Test
+    @AndroidJUnitIgnore
+    @JSIgnore
+    fun validationBehavior_firesFocusLostCallback() = runComposeUiTest {
+        var lost = 0
+        setContent {
+            Column {
+                TextField(
+                    value = "", onValueChange = {},
+                    modifier = Modifier
+                        .testTag("a")
+                        .validationBehavior(isError = true, onFocusLost = { lost++ }),
+                )
+                TextField(value = "", onValueChange = {}, modifier = Modifier.testTag("b"))
+            }
+        }
+        onNodeWithTag("a").requestFocus()
+        assertEquals(0, lost)
+        onNodeWithTag("b").requestFocus()
+        assertEquals(1, lost)
+    }
+
+    @Test
+    fun validationBehavior_withNoParamsIsTrulyANoOp() {
+        // A plain assertion, no composition needed: with both optional params null the
+        // implementation is `this.then(Modifier).then(Modifier)`, and Modifier.then(Modifier)
+        // returns the receiver — so the whole call must collapse to Modifier itself.
+        assertEquals(Modifier, Modifier.validationBehavior(isError = true))
+    }
+
+    @Test
+    @AndroidJUnitIgnore
+    @JSIgnore
+    fun validationBehavior_isNotHijackedByValidatorMemberScope() = runComposeUiTest {
+        // Inside with(validator), Kotlin prefers MEMBERS over extensions. Had the free
+        // function been named validationConfig, this call would have silently bound to
+        // the member and set validateOnFocusLost instead of isError.
+        val validator = TextFieldValueValidator(value = "")
+        var lost = 0
+        setContent {
+            with(validator) {
+                Column {
+                    TextField(
+                        value = "", onValueChange = {},
+                        modifier = Modifier
+                            .testTag("a")
+                            .validationBehavior(isError = true, onFocusLost = { lost++ }),
+                    )
+                    TextField(value = "", onValueChange = {}, modifier = Modifier.testTag("b"))
+                }
+            }
+        }
+        onNodeWithTag("a").requestFocus()
+        onNodeWithTag("b").requestFocus()
+        assertEquals(1, lost, "the free function must win — the member has no onFocusLost param")
     }
 }

--- a/library/src/commonTest/kotlin/com/chrisjenx/yakcov/ModifiersShakeTest.kt
+++ b/library/src/commonTest/kotlin/com/chrisjenx/yakcov/ModifiersShakeTest.kt
@@ -14,6 +14,7 @@ import androidx.compose.ui.test.v2.runComposeUiTest
 import com.chrisjenx.yakcov.strings.TextFieldValueValidator
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 
 @OptIn(ExperimentalTestApi::class)
 class ModifiersShakeTest {
@@ -220,5 +221,94 @@ class ModifiersShakeTest {
         // crashing composition (a throw there would have already failed at setContent /
         // waitForIdle above); requestFocus() re-confirms the node is still alive afterward.
         onNodeWithTag("a").requestFocus()
+    }
+
+    @Test
+    @AndroidJUnitIgnore
+    @JSIgnore
+    fun shakeOnInvalid_actuallyAnimatesXPosition() = runComposeUiTest {
+        // The wiring proof the parked finding asked for: with an injected ShakingState we can see
+        // that shakeOnInvalid really drives ShakingState.shake(), i.e. that translationX moves.
+        // Deleting shakable()/shake() from the modifier makes this fail instead of passing silently.
+        val shakingState = ShakingState(ShakingState.Strength.Custom(20f), ShakingState.Direction.LEFT_THEN_RIGHT)
+        var trigger by mutableStateOf(0)
+        mainClock.autoAdvance = false
+        setContent {
+            TextField(
+                value = "", onValueChange = {},
+                modifier = Modifier
+                    .testTag("a")
+                    .shakeOnInvalid(isError = true, trigger = trigger, shakingState = shakingState),
+            )
+        }
+        mainClock.advanceTimeByFrame()
+        assertEquals(0f, shakingState.xPosition.value, "must be at rest before any trigger change")
+        trigger = 1
+        // Sample the first stretch of the shake: each animateTo leg is 20ms, so within the first
+        // ~10ms of an animation the value must have left 0f. Take the max magnitude across a few
+        // frames so we don't land exactly on a 0-crossing.
+        var maxAbs = 0f
+        var maxBoundsShift = 0f
+        repeat(3) {
+            mainClock.advanceTimeBy(10L)
+            val x = shakingState.xPosition.value
+            if (x < 0f) { if (-x > maxAbs) maxAbs = -x } else if (x > maxAbs) maxAbs = x
+            // Also observe the node's on-screen bounds: graphicsLayer translationX shows up in
+            // boundsInRoot, so this half fails if shakable(shakingState) is ever dropped from the
+            // chain (asserting on xPosition alone would not notice).
+            val shift = onNodeWithTag("a").fetchSemanticsNode().boundsInRoot.left
+            if (shift < 0f) { if (-shift > maxBoundsShift) maxBoundsShift = -shift }
+            else if (shift > maxBoundsShift) maxBoundsShift = shift
+        }
+        assertTrue(maxAbs > 0f, "xPosition must move while shaking, was max |x| = $maxAbs")
+        assertTrue(
+            maxBoundsShift > 0f,
+            "the node must actually be translated on screen (shakable must be in the chain), " +
+                "was max |shift| = $maxBoundsShift",
+        )
+    }
+
+    @Test
+    @AndroidJUnitIgnore
+    @JSIgnore
+    fun shakeOnInvalid_newTriggerMidShakeDoesNotLeaveTheFieldOffset() = runComposeUiTest {
+        // Regression: LaunchedEffect(trigger) CANCELS the in-flight shake when trigger changes. If
+        // the restart's isError guard then skips (the value was corrected mid-animation, e.g. by
+        // autofill), xPosition is stranded wherever animateTo was interrupted and the field renders
+        // permanently offset. The shake must always unwind to 0f.
+        val shakingState = ShakingState(ShakingState.Strength.Custom(20f), ShakingState.Direction.LEFT_THEN_RIGHT)
+        var trigger by mutableStateOf(0)
+        var isError by mutableStateOf(true)
+        mainClock.autoAdvance = false
+        setContent {
+            TextField(
+                value = "", onValueChange = {},
+                modifier = Modifier
+                    .testTag("a")
+                    .shakeOnInvalid(isError = isError, trigger = trigger, shakingState = shakingState),
+            )
+        }
+        mainClock.advanceTimeByFrame()
+        trigger = 1
+        // Step forward until the shake has actually left 0f, so the cancellation below happens
+        // mid-animateTo (the whole point). Small steps avoid landing on a 0-crossing.
+        var offset = 0f
+        repeat(20) {
+            if (offset != 0f) return@repeat
+            mainClock.advanceTimeBy(5L)
+            offset = shakingState.xPosition.value
+        }
+        assertTrue(
+            offset != 0f,
+            "precondition: the shake must be mid-flight (off 0f) for this test to be meaningful",
+        )
+        // Value corrected + re-submitted inside the ~240ms shake window.
+        isError = false
+        trigger = 2
+        repeat(4) { mainClock.advanceTimeByFrame() }
+        assertEquals(
+            0f, shakingState.xPosition.value,
+            "a cancelled shake must snap back to 0f, not strand the field offset",
+        )
     }
 }

--- a/library/src/commonTest/kotlin/com/chrisjenx/yakcov/ModifiersShakeTest.kt
+++ b/library/src/commonTest/kotlin/com/chrisjenx/yakcov/ModifiersShakeTest.kt
@@ -230,7 +230,7 @@ class ModifiersShakeTest {
         // The wiring proof the parked finding asked for: with an injected ShakingState we can see
         // that shakeOnInvalid really drives ShakingState.shake(), i.e. that translationX moves.
         // Deleting shakable()/shake() from the modifier makes this fail instead of passing silently.
-        val shakingState = ShakingState(ShakingState.Strength.Custom(20f), ShakingState.Direction.LEFT_THEN_RIGHT)
+        val shakingState = ShakingState(ShakeStrength, ShakeDirection)
         var trigger by mutableStateOf(0)
         mainClock.autoAdvance = false
         setContent {
@@ -276,7 +276,7 @@ class ModifiersShakeTest {
         // the restart's isError guard then skips (the value was corrected mid-animation, e.g. by
         // autofill), xPosition is stranded wherever animateTo was interrupted and the field renders
         // permanently offset. The shake must always unwind to 0f.
-        val shakingState = ShakingState(ShakingState.Strength.Custom(20f), ShakingState.Direction.LEFT_THEN_RIGHT)
+        val shakingState = ShakingState(ShakeStrength, ShakeDirection)
         var trigger by mutableStateOf(0)
         var isError by mutableStateOf(true)
         mainClock.autoAdvance = false

--- a/library/src/commonTest/kotlin/com/chrisjenx/yakcov/ModifiersShakeTest.kt
+++ b/library/src/commonTest/kotlin/com/chrisjenx/yakcov/ModifiersShakeTest.kt
@@ -1,0 +1,101 @@
+package com.chrisjenx.yakcov
+
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.v2.runComposeUiTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+@OptIn(ExperimentalTestApi::class)
+class ModifiersShakeTest {
+
+    @Test
+    @AndroidJUnitIgnore
+    @JSIgnore
+    fun doesNotShakeOnFirstComposition_evenWhenAlreadyInError() = runComposeUiTest {
+        var shakes = 0
+        setContent {
+            // Starts in error with a non-zero trigger: an initialValidate field must not shake.
+            ShakeOnTriggerEffect(isError = true, trigger = 7) { shakes++ }
+        }
+        waitForIdle()
+        assertEquals(0, shakes)
+    }
+
+    @Test
+    @AndroidJUnitIgnore
+    @JSIgnore
+    fun shakesWhenTriggerChangesWhileInError() = runComposeUiTest {
+        var shakes = 0
+        var trigger by mutableStateOf(0)
+        setContent {
+            ShakeOnTriggerEffect(isError = true, trigger = trigger) { shakes++ }
+        }
+        waitForIdle()
+        assertEquals(0, shakes)
+        trigger = 1
+        waitForIdle()
+        assertEquals(1, shakes)
+    }
+
+    @Test
+    @AndroidJUnitIgnore
+    @JSIgnore
+    fun eachRepeatedInvalidSubmitShakes() = runComposeUiTest {
+        // THE defect this exists to fix: a second invalid submit produces an EQUAL
+        // FieldValidationState, so a state-diff-driven shake would never re-fire.
+        var shakes = 0
+        var trigger by mutableStateOf(0)
+        setContent {
+            ShakeOnTriggerEffect(isError = true, trigger = trigger) { shakes++ }
+        }
+        waitForIdle()
+        trigger = 1
+        waitForIdle()
+        trigger = 2
+        waitForIdle()
+        assertEquals(2, shakes)
+    }
+
+    @Test
+    @AndroidJUnitIgnore
+    @JSIgnore
+    fun doesNotShakeWhenNotInError() = runComposeUiTest {
+        var shakes = 0
+        var trigger by mutableStateOf(0)
+        setContent {
+            ShakeOnTriggerEffect(isError = false, trigger = trigger) { shakes++ }
+        }
+        waitForIdle()
+        trigger = 1
+        waitForIdle()
+        assertEquals(0, shakes)
+    }
+
+    @Test
+    @AndroidJUnitIgnore
+    @JSIgnore
+    fun disposalResetsTheBaseline_knownLimitation() = runComposeUiTest {
+        // Locks in a KNOWN LIMITATION rather than asserting desirable behaviour: `remember`
+        // cannot tell "new field" from "same field re-created after its subtree was disposed"
+        // (a LazyColumn item without a stable key, or a nav destination re-entered). Increments
+        // that happened while disposed are swallowed. If this test ever starts failing, the
+        // guard became smarter — update the limitation note in docs, don't just delete the test.
+        var shakes = 0
+        var trigger by mutableStateOf(0)
+        var present by mutableStateOf(true)
+        setContent {
+            if (present) ShakeOnTriggerEffect(isError = true, trigger = trigger) { shakes++ }
+        }
+        waitForIdle()
+        present = false
+        waitForIdle()
+        trigger = 5           // bumped while disposed
+        waitForIdle()
+        present = true        // recomposed fresh: 5 becomes the new baseline
+        waitForIdle()
+        assertEquals(0, shakes)
+    }
+}

--- a/library/src/commonTest/kotlin/com/chrisjenx/yakcov/ModifiersShakeTest.kt
+++ b/library/src/commonTest/kotlin/com/chrisjenx/yakcov/ModifiersShakeTest.kt
@@ -140,9 +140,14 @@ class ModifiersShakeTest {
     @AndroidJUnitIgnore
     @JSIgnore
     fun validationBehavior_isNotHijackedByValidatorMemberScope() = runComposeUiTest {
-        // Inside with(validator), Kotlin prefers MEMBERS over extensions. Had the free
-        // function been named validationConfig, this call would have silently bound to
-        // the member and set validateOnFocusLost instead of isError.
+        // Canary, not proof: there is no validationBehavior MEMBER on ValueValidator, so this
+        // test cannot demonstrate the free function "winning" a resolution contest today — it
+        // only exercises validationBehavior inside `with(validator) { }`. What it guards against
+        // is future regression: if someone later adds a colliding `validationBehavior` member to
+        // ValueValidator, Kotlin's member-over-extension resolution would silently bind here, and
+        // this test would start failing (the member has no onFocusLost param) rather than the
+        // collision going unnoticed. The actual naming-collision case this branch dodged is
+        // covered by validationConfig_memberStillBindsToMemberInsideWithValidator below.
         val validator = TextFieldValueValidator(value = "")
         var lost = 0
         setContent {
@@ -160,6 +165,60 @@ class ModifiersShakeTest {
         }
         onNodeWithTag("a").requestFocus()
         onNodeWithTag("b").requestFocus()
-        assertEquals(1, lost, "the free function must win — the member has no onFocusLost param")
+        assertEquals(1, lost, "validationBehavior's onFocusLost must fire from inside with(validator)")
+    }
+
+    @Test
+    @AndroidJUnitIgnore
+    @JSIgnore
+    fun validationConfig_memberStillBindsToMemberInsideWithValidator() = runComposeUiTest {
+        // The other half of the naming decision: inside with(validator) { }, the unqualified
+        // call `Modifier.validationConfig(...)` must still resolve to the ValueValidator MEMBER
+        // (member-over-extension), not to some free function. Required is the validator's
+        // default rule, so a blank value fails validation; validateOnFocusLost = true means
+        // losing focus should trigger validate() and flip isError() to true.
+        val validator = TextFieldValueValidator(value = "")
+        setContent {
+            with(validator) {
+                Column {
+                    TextField(
+                        value = "", onValueChange = {},
+                        modifier = Modifier
+                            .testTag("a")
+                            .validationConfig(validateOnFocusLost = true),
+                    )
+                    TextField(value = "", onValueChange = {}, modifier = Modifier.testTag("b"))
+                }
+            }
+        }
+        onNodeWithTag("a").requestFocus()
+        assertEquals(false, validator.isError())
+        onNodeWithTag("b").requestFocus()
+        assertEquals(true, validator.isError())
+    }
+
+    @Test
+    @AndroidJUnitIgnore
+    @JSIgnore
+    fun shakeOnInvalid_composesThePublicModifier() = runComposeUiTest {
+        // Every other shake test targets the internal ShakeOnTriggerEffect. This is the only
+        // test that materializes the PUBLIC Modifier.shakeOnInvalid, so it would catch a
+        // shakeOnInvalid (or validationBehavior) that dropped its shakable(shakingState) call.
+        var trigger by mutableStateOf(0)
+        setContent {
+            TextField(
+                value = "", onValueChange = {},
+                modifier = Modifier
+                    .testTag("a")
+                    .shakeOnInvalid(isError = true, trigger = trigger),
+            )
+        }
+        waitForIdle()
+        trigger = 1
+        waitForIdle()
+        // Proves the public modifier composed successfully and its shake branch ran without
+        // crashing composition (a throw there would have already failed at setContent /
+        // waitForIdle above); requestFocus() re-confirms the node is still alive afterward.
+        onNodeWithTag("a").requestFocus()
     }
 }

--- a/sample/src/main/java/com/chrisjenx/yakcov/sample/MviSample.kt
+++ b/sample/src/main/java/com/chrisjenx/yakcov/sample/MviSample.kt
@@ -24,12 +24,12 @@ import com.chrisjenx.yakcov.FieldValidationState
 import com.chrisjenx.yakcov.RegularValidationResult
 import com.chrisjenx.yakcov.ValueValidatorRule
 import com.chrisjenx.yakcov.hasNoErrors
-import com.chrisjenx.yakcov.onFocusLost
 import com.chrisjenx.yakcov.strings.Email
 import com.chrisjenx.yakcov.strings.MinLength
 import com.chrisjenx.yakcov.strings.Required
 import com.chrisjenx.yakcov.supportingText
 import com.chrisjenx.yakcov.toFieldState
+import com.chrisjenx.yakcov.validationBehavior
 
 /* =====================================================================================
  * REDUCER-MVI integration of the yakcov *headless* validator.
@@ -78,6 +78,12 @@ data class Model(
     val confirmState: FieldValidationState = FieldValidationState.Pristine,
     /** Submit outcome: null = not attempted, true = accepted, false = blocked (show errors + shake). */
     val submitted: Boolean? = null,
+    /**
+     * Monotonic shake trigger for [Modifier.validationBehavior]. Bumped ONLY alongside the same
+     * `copy(...)` that surfaces errors on Submit, so `showError` and this counter always land in the
+     * same composition — no ordering race between "is it an error" and "did the trigger change".
+     */
+    val submitAttempts: Int = 0,
 ) {
     /**
      * Form-level validity, driven purely by SEVERITY (ignores showError), so the UI can react to
@@ -151,11 +157,13 @@ fun reduce(model: Model, event: Event): Model = when (event) {
     }
 
     Event.Submit -> {
-        // Show errors on every field (force showError = true), then read validity off severity.
+        // Show errors on every field (force showError = true) AND bump the shake trigger in the SAME
+        // copy(...) — so isError and the new trigger value arrive together, in one composition.
         val surfaced = model.copy(
             emailState = emailRules.toFieldState(model.emailDraft, showError = true),
             passwordState = passwordRules.toFieldState(model.passwordDraft, showError = true),
             confirmState = confirmRules(model.passwordDraft).toFieldState(model.confirmDraft, showError = true),
+            submitAttempts = model.submitAttempts + 1,
         )
         surfaced.copy(submitted = surfaced.canSubmit)
     }
@@ -225,6 +233,7 @@ private fun MviTextField(
     state: FieldValidationState,
     onChanged: (String) -> Unit,
     onFocusLost: () -> Unit,
+    shakeTrigger: Int,
     keyboardType: KeyboardType = KeyboardType.Text,
     mask: Boolean = false,
 ) {
@@ -244,7 +253,14 @@ private fun MviTextField(
         visualTransformation = if (mask) PasswordVisualTransformation() else VisualTransformation.None,
         modifier = Modifier
             .fillMaxWidth()
-            .onFocusLost(onFocusLost),             // show-on-focus-loss for this field
+            // Bundles show-on-focus-loss with shake-on-invalid-submit-retry, driven by the model's
+            // monotonic submitAttempts counter (state diffing can't drive this: a second invalid
+            // submit produces an `==` FieldValidationState, so a state-diff shake would fire once).
+            .validationBehavior(
+                isError = state.isError,
+                shakeTrigger = shakeTrigger,
+                onFocusLost = onFocusLost,
+            ),
     )
 }
 
@@ -264,6 +280,7 @@ fun MviFormSample() {
         state = model.emailState,
         onChanged = { store.dispatch(Event.Changed(Field.Email, it)) },
         onFocusLost = { store.dispatch(Event.FocusLost(Field.Email)) },
+        shakeTrigger = model.submitAttempts,
         keyboardType = KeyboardType.Email,
     )
     MviTextField(
@@ -272,6 +289,7 @@ fun MviFormSample() {
         state = model.passwordState,
         onChanged = { store.dispatch(Event.Changed(Field.Password, it)) },
         onFocusLost = { store.dispatch(Event.FocusLost(Field.Password)) },
+        shakeTrigger = model.submitAttempts,
         keyboardType = KeyboardType.Password,
         mask = true,
     )
@@ -281,6 +299,7 @@ fun MviFormSample() {
         state = model.confirmState,
         onChanged = { store.dispatch(Event.Changed(Field.Confirm, it)) },
         onFocusLost = { store.dispatch(Event.FocusLost(Field.Confirm)) },
+        shakeTrigger = model.submitAttempts,
         keyboardType = KeyboardType.Password,
         mask = true,
     )
@@ -297,7 +316,8 @@ fun MviFormSample() {
     ) { Text(if (model.canSubmit) "Create account" else "Fix errors to submit") }
 
     // Submit outcome. `false` occurs when Submit surfaces a still-invalid field the user never focused
-    // (submit-first, or an untouched required field) — a clean point to drive a shake on `false`
-    // (keep ShakingState UI-owned).
+    // (submit-first, or an untouched required field). Each MviTextField above already shakes on this:
+    // `submitAttempts` bumped in the same reduce() copy(...) that set showError = true, so every
+    // repeat invalid submit gets its own shake even though the resulting FieldValidationState is `==`.
     model.submitted?.let { Text(if (it) "Valid — proceeding" else "Fix the errors above") }
 }

--- a/sample/src/main/java/com/chrisjenx/yakcov/sample/PresenterSample.kt
+++ b/sample/src/main/java/com/chrisjenx/yakcov/sample/PresenterSample.kt
@@ -14,8 +14,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.TextRange
 import androidx.compose.ui.text.input.TextFieldValue
 import com.chrisjenx.yakcov.FieldValidator
-import com.chrisjenx.yakcov.onFocusLost
 import com.chrisjenx.yakcov.validate
+import com.chrisjenx.yakcov.validationBehavior
 import com.chrisjenx.yakcov.supportingText
 import com.chrisjenx.yakcov.strings.Email
 import com.chrisjenx.yakcov.strings.Required
@@ -56,7 +56,13 @@ fun ValidatedTextField(
         supportingText = field.state.supportingText(),
         modifier = modifier
             .fillMaxWidth()
-            .onFocusLost { field.onFocusLost() },
+            // field.attempts is bumped only by validate() (never onFocusLost()) and never resets, so
+            // every repeat invalid submit shakes even though the resulting state is `==` to the last.
+            .validationBehavior(
+                isError = field.state.isError,
+                shakeTrigger = field.attempts,
+                onFocusLost = { field.onFocusLost() },
+            ),
     )
 }
 
@@ -71,5 +77,5 @@ fun PresenterFormSample() {
         onClick = { submitted = presenter.submit() },
         modifier = Modifier.fillMaxWidth(),
     ) { Text("Submit") }
-    submitted?.let { Text(if (it) "Valid — proceeding" else "Invalid — shake here") }
+    submitted?.let { Text(if (it) "Valid — proceeding" else "Fix the errors above") }
 }


### PR DESCRIPTION
## Problem

Yakcov's per-field `Modifier` config is declared as **members** of the validator classes, so it only exists inside `with(validator) { }` and cannot be imported. Reducer-MVI code — the value-hoist pattern this repo's own `docs/patterns/mvi.md` recommends — has no validator object at all, so it could not reach any of it. A single composable signature serving all three paths (in-composition `ValueValidator`, headless `FieldValidator`, pure reducer) was impossible to write.

Being precise about the gap, because an earlier framing overstated it: `Modifier.onFocusLost` was **already** free and already used on the reducer path. The two genuinely missing capabilities were a **shake trigger drivable from plain values**, and **`onFocusCursorToEnd`** outside `TextFieldValueValidator`.

## What this adds

Free functions in `Modifiers.kt`, over plain values:

```kotlin
fun Modifier.shakeOnInvalid(isError: Boolean, trigger: Int): Modifier
fun Modifier.validationBehavior(isError: Boolean, shakeTrigger: Int? = null, onFocusLost: (() -> Unit)? = null): Modifier
@Composable fun Modifier.onFocusCursorToEnd(value: TextFieldValue, onValueChange: (TextFieldValue) -> Unit, scope: CoroutineScope = rememberCoroutineScope(), highlight: Boolean = false): Modifier
```

Plus `FieldValidator.attempts` — a monotonic counter incremented by `validate()` but **not** `onFocusLost()` (matching `ValueValidator`'s deliberate "don't shake on focus loss"), and never reset. `TextFieldValueValidator.onFocusCursorToEnd` keeps its signature and delegates to the free form.

**Why a counter and not a state diff.** `FieldValidationState` equality intentionally includes its message, so a *second* invalid submit produces an `==` state — no recomposition, and a diff-driven shake fires once and then never again. Only a monotonic trigger re-fires.

## Notable decisions

- **`validationBehavior`, not `validationConfig`.** The latter is a `ValueValidator` member taking a leading `Boolean`; Kotlin resolves members over extensions, so a same-named free function would silently bind to the member and set `validateOnFocusLost` instead of `isError`, with no compiler diagnostic.
- **`ValueValidator` is untouched.** Two shake mechanisms now exist on disjoint classes. That's deliberate: adding `attempts` there was what would have *created* a "don't enable both" footgun, so not adding it removes the footgun with no rewire of the mature path.
- **Public API is now gated.** The repo had no API validation at all — no plugin, no dumps, no `explicitApi` — so every release shipped blind on API drift. Adds Kotlin's built-in `abiValidation`, committed dumps under `library/api/`, and an unmatrixed `Checks-Api` job wired into `CI-Gate`.

## A real bug this caught

`LaunchedEffect(trigger)` **cancels** an in-flight `shake()`. If `isError` is false on the restart, the guard skips and `xPosition` is left mid-animation — so `graphicsLayer { translationX = … }` renders the field **permanently offset**. This is a regression against the replaced mechanism, which launched into a detached scope so `Animatable` always completed back to `0f`. Fixed with `try`/`finally` + a `NonCancellable` `snapTo(0f)`. Fail-before evidence was `expected:<0.0> but was:<-20.0>` — exactly the full `Custom(20f)` deflection.

## Testing

168 tests, 0 failures. `checkKotlinAbi` green with the dump matching. `:docs-examples:compileKotlinJvm` and `:sample:compileDebugKotlin` both build.

The shake-wiring test was **proven by mutation**: an earlier draft asserting only `xPosition != 0f` survived deleting `shakable(shakingState)`, so it now also asserts `boundsInRoot`, which fails under that mutation.

Docs and the demo are updated: `MviSample.kt` and `PresenterSample.kt` previously held placeholders (`"Invalid — shake here"`, `"keep ShakingState UI-owned"`) exactly where these primitives belong, while `docs/patterns/mvi.md` pointed readers at the sample for a pattern it didn't implement.

## Reviewer notes

- **`Checks-Api` now passes in CI** (first execution was on this PR). It is stable-only and unmatrixed by design — see below.
- **iOS klib ABI isn't truly validated**: `Checks-Api` runs on `ubuntu-latest` and `klib.keepUnsupportedTargets` defaults true, so Apple entries pass by inference. js/wasmJs still catch common-API drift.
- **Known limitations, all documented**: shake is visual only (silent to screen readers); a field re-created after subtree disposal adopts the current counter as its baseline and swallows a due shake (use a stable `key`); `onFocusCursorToEnd` on the UDF path needs `TextFieldValue` in the model, not `String`.
- `ValueValidator.kt` still spells the shake constants inline; unifying them with the new `internal` ones would mean editing a file this PR deliberately leaves alone, so it's left as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



## Follow-up fix: the ABI gate vs. the `[next]` channel

Review of this branch surfaced a regression it had introduced, now fixed in `d6ce06c`.

**What broke.** The `abiValidation` block named `enabled` and `klib`, both *removed* in Kotlin 2.4. On the `[next]` channel those are deprecation-level **errors**, so `library/build.gradle.kts` failed its own script compilation. That broke all three `next` CI legs — and more seriously `release.yml`'s next-channel **publish**, which patches versions before invoking Gradle. `CI-Gate` stayed green throughout because the `next` legs are `continue-on-error`, so this would have merged unnoticed.

**Why deleting the two properties wasn't enough.** On Kotlin 2.3 an empty block leaves validation *off*, and `checkKotlinAbi` is then `SKIPPED` — a gate that passes while validating nothing. Established by mutation test (add a public symbol; the check must fail):

| Form | Stable (2.3) | Next (2.4) |
|---|---|---|
| `enabled.set(true)` + `klib.…` | gate live, canary caught | **script won't compile** |
| empty block | `SKIPPED` — **vacuous pass** | compiles |
| reflective `enabled` | gate live, canary caught | compiles, 168/168 tests green |

No static form satisfies both channels, so `enabled` is set reflectively: present on 2.3 (gate live), absent on 2.4 (no-op). A version-string gate was considered and rejected — it reproduces the silent-inert failure mode the day stable moves to 2.4, and a gate that quietly stops validating is worse than one that fails loudly.

**Dry-run exclusion.** `:library:build` includes `checkKotlinAbi` in its task graph, and the dumps are toolchain-specific (2.4 stops emitting the synthetic `DefaultConstructorMarker` bridge constructors), so a stable-generated dump can never match another channel's compiler. `release.yml`'s dry-run now passes `-x :library:checkKotlinAbi`. No coverage is lost: `Checks-Api` gates every PR, and that redundant re-run could only ever fail on the channel mismatch.

**No breaking API changes.** The `library/api/` dumps are new on this branch (2137 insertions, zero deletions) — there is no prior baseline to break, and every change is additive.